### PR TITLE
Reset Password Page and Features

### DIFF
--- a/backend/Controllers/EmailController.cs
+++ b/backend/Controllers/EmailController.cs
@@ -22,5 +22,12 @@ namespace Backend.Controllers
         {
             return await _emailService.SendRegistrationEmailAsync(user);
         }
+
+        [Authorize]
+        [HttpPost("ResetPassword")]
+        public async Task<bool> SendResetPasswordEmail([FromBody] UserModel user)
+        {
+            return await _emailService.SendResetPasswordEmailAsync(user);
+        }
     }
 }

--- a/backend/Services/IEmailService.cs
+++ b/backend/Services/IEmailService.cs
@@ -5,5 +5,7 @@ namespace Backend.Services
     public interface IEmailService
     {
         public Task<bool> SendRegistrationEmailAsync(UserModel user);
+
+        public Task<bool> SendResetPasswordEmailAsync(UserModel user);
     }
 }

--- a/backend/Util/ApplicationConstants.cs
+++ b/backend/Util/ApplicationConstants.cs
@@ -1,4 +1,5 @@
-﻿using Backend.Models;
+﻿using Amazon.S3.Model;
+using Backend.Models;
 
 namespace Util.Constants
 {
@@ -92,6 +93,15 @@ namespace Util.Constants
             "Kind Regards, \n" +
             "InstaConnect Team";
         static public readonly string RegistrationURL = "http://localhost:3000/setPassword?token={0}";
+        #endregion
+
+        #region Reset Password Email
+        static public readonly string ResetPasswordSubject = "Reset your InstaConnect Password";
+        static public readonly string ResetPasswordBody = "Dear {0}, \n\n" +
+            "We've receved a request to reset the password for your InstaConnect account. If you did not make this request please ignore this email. \n\n" +
+            "In order to finish resetting your password please click the following link {1}. \n\n" +
+            "Kind regards, \n" +
+            "InstaConnect Team";
         #endregion
 
         #region Authentication

--- a/frontend/landing-page/.gitignore
+++ b/frontend/landing-page/.gitignore
@@ -1,24 +1,2 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
-# dependencies
 /node_modules
-/.pnp
-/.env
-.pnp.js
-
-# testing
-/coverage
-
-# production
-/build
-
-# misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+.env

--- a/frontend/landing-page/package-lock.json
+++ b/frontend/landing-page/package-lock.json
@@ -6140,9 +6140,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6151,6 +6151,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },

--- a/frontend/landing-page/public/index.html
+++ b/frontend/landing-page/public/index.html
@@ -1,43 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta
+    name="description"
+    content="Web site created using create-react-app"
+  />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
+    manifest.json provides metadata used when your web app is installed on a
+    user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+  -->
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
+    Notice the use of %PUBLIC_URL% in the tags above.
+    It will be replaced with the URL of the `public` folder during the build.
+    Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+    work correctly both with client-side routing and a non-root public URL.
+    Learn how to configure a non-root public URL by running `npm run build`.
+  -->
+  <head>
     <title>InstaConnect</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/frontend/landing-page/src/App.tsx
+++ b/frontend/landing-page/src/App.tsx
@@ -1,12 +1,13 @@
-import './App.css';
+import './App.css'
 import React from 'react'
-import { LoginPage } from './pages/LoginPage';
+import { LoginPage } from './pages/LoginPage'
 import { AuthenticationApiClient } from './api_views/AuthenticationApiClient'
-import RegisterPage from './pages/RegisterPage';
-import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
-import { UserApiClient } from './api_views/UserApiClient';
-import SetPasswordPage from './pages/SetPasswordPage';
-import { EmailApiClient } from './api_views/EmailApiClient';
+import RegisterPage from './pages/RegisterPage'
+import SetPasswordPage from './pages/SetPasswordPage'
+import ResetPasswordPage from './pages/ResetPasswordPage'
+import { Route, BrowserRouter as Router, Routes } from 'react-router-dom'
+import { UserApiClient } from './api_views/UserApiClient'
+import { EmailApiClient } from './api_views/EmailApiClient'
 
 export const _authenticationApiClient = new AuthenticationApiClient()
 export const _userApiClient = new UserApiClient()
@@ -20,6 +21,7 @@ function App() {
           <Route path="/" element={<LoginPage/>}/>
           <Route path="/register" element={<RegisterPage/>}/>
           <Route path="/setPassword" element={<SetPasswordPage/>}/>
+          <Route path="/resetPassword" element={<ResetPasswordPage/>}/>
         </Routes>
       </Router>
     </div>

--- a/frontend/landing-page/src/App.tsx
+++ b/frontend/landing-page/src/App.tsx
@@ -13,6 +13,8 @@ export const _authenticationApiClient = new AuthenticationApiClient()
 export const _userApiClient = new UserApiClient()
 export const _emailApiClient = new EmailApiClient()
 
+console.log(process.env.REACT_APP_GUEST_PASSWORD!)
+
 function App() {
   return (
     <div className = "App">

--- a/frontend/landing-page/src/api_views/EmailApiClient.ts
+++ b/frontend/landing-page/src/api_views/EmailApiClient.ts
@@ -18,4 +18,13 @@ export class EmailApiClient extends BaseApiClient implements IEmailApiClient{
             statusCode: response.statusCode
         }
     }
+
+    sendResetPasswordEmail = async(user: UserModel, header: AxiosRequestConfig): Promise<GenericResponse<boolean>> => {
+        const response = await this.postApi("resetPassword", user, header)
+        return {
+            data: response.data as boolean,
+            message: response.message ?? '',
+            statusCode: response.statusCode
+        }
+    }
 }

--- a/frontend/landing-page/src/api_views/IEmailApiClient.ts
+++ b/frontend/landing-page/src/api_views/IEmailApiClient.ts
@@ -4,4 +4,6 @@ import { GenericResponse, UserModel } from "./IBaseApiClient"
 export interface IEmailApiClient {
 
     sendRegistrationEmail: (user: UserModel, header: AxiosRequestConfig) => Promise<GenericResponse<boolean>>
+
+    sendResetPasswordEmail: (user: UserModel, header: AxiosRequestConfig) => Promise<GenericResponse<boolean>>
 }

--- a/frontend/landing-page/src/api_views/UserApiClient.ts
+++ b/frontend/landing-page/src/api_views/UserApiClient.ts
@@ -4,7 +4,7 @@ import { UserEndpoint } from '../utils/Constants'
 import { IUserApiClient } from './IUserApiClient'
 import { AxiosRequestConfig } from 'axios'
 
-export class UserApiClient extends BaseApiClient implements IUserApiClient{
+export class UserApiClient extends BaseApiClient implements IUserApiClient {
 
     constructor () {
         super(UserEndpoint)
@@ -12,6 +12,15 @@ export class UserApiClient extends BaseApiClient implements IUserApiClient{
 
     createUser = async(user: UserModel, header: AxiosRequestConfig): Promise<GenericResponse<UserModel>> => {
         const response = await this.postApi<UserModel, UserModel>("user", user, header)
+        return {
+            data: response.data,
+            message: response.message ?? "",
+            statusCode: response.statusCode
+        }
+    }
+
+    getUser = async(email: string, header: AxiosRequestConfig): Promise<GenericResponse<UserModel>> => {
+        const response = await this.getApi<UserModel>(`user?email=${email}`, header)
         return {
             data: response.data,
             message: response.message ?? "",

--- a/frontend/landing-page/src/components/PasswordForm.tsx
+++ b/frontend/landing-page/src/components/PasswordForm.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
-import { Formik, ErrorMessage, FormikProps, FormikHelpers, FormikErrors, Form } from 'formik'
+import { Formik, ErrorMessage, FormikHelpers, FormikErrors, Form } from 'formik'
 import * as Yup from 'yup'
 import { Button, FormControl, Grid, TextField } from '@mui/material'
 import { FormProperties } from '../utils/FormProperties'
 import LoginRegisterAlert from './LoginRegisterAlert'
-import { _userApiClient, _authenticationApiClient, _emailApiClient} from '../App'
+import { _authenticationApiClient } from '../App'
 import { GenericResponse, UserModel } from '../api_views/IBaseApiClient'
 import { AxiosRequestConfig } from 'axios'
-import { GuestEmail, GuestPassword, Paths } from '../utils/Constants'
+import { Paths } from '../utils/Constants'
 import LoginHeader from './LoginHeader'
 import { useNavigate } from 'react-router-dom'
 
@@ -34,10 +34,6 @@ export const PasswordForm = (prop: PasswordProps) => {
         confirmPassword: ''
     }
 
-    const goToLoginScreen = () => {
-        navigate(Paths['Login'], { replace: true })
-    }
-
     const onSubmit = async(values: PasswordFormValues, { setSubmitting, resetForm, validateForm }: FormikHelpers<PasswordFormValues>): Promise<void> => {
         if (!values.password || !values.confirmPassword) {
             setPasswordResult({
@@ -58,7 +54,7 @@ export const PasswordForm = (prop: PasswordProps) => {
             setSubmitting(false)
             return
         }
-        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(GuestEmail, GuestPassword)
+        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(process.env.REACT_APP_GUEST_EMAIL!, process.env.REACT_APP_GUEST_PASSWORD!)
         if (jwtResponse.data) {
             const header: AxiosRequestConfig = {headers: {Authorization: 'Bearer ' + jwtResponse.data}}
             const response: GenericResponse<UserModel>  = await _authenticationApiClient.register(prop.email, values.confirmPassword, header)
@@ -111,41 +107,41 @@ export const PasswordForm = (prop: PasswordProps) => {
                         <>
                             <LoginHeader sideButton='Login' sideButtonPath={Paths['Login']}/>
                             <Form>
-                            <Grid container spacing={5} direction='column' justifyContent='center' alignItems='center' sx={{ minHeight: '100vh' }}>
-                                <Grid item xs={12} sx={{maxHeight:'100px'}}>
-                                    <FormControl sx={{ verticalAlign: 'center', m: 1, width: '60ch' }} variant='outlined'>
-                                        <TextField
-                                        id='outlined-adornment-password'
-                                        type='password'
-                                        label='Password'
-                                        name='password'
-                                        value={formik.values.password}
-                                        onChange={formik.handleChange}
-                                        onBlur={formik.handleBlur}
-                                        error={formik.errors.password && formik.touched.password ? true : false}
-                                        helperText={formik.errors.password && <ErrorMessage name='password'/>}
-                                        />
-                                    </FormControl>
+                                <Grid container spacing={5} direction='column' justifyContent='center' alignItems='center' sx={{ minHeight: '100vh' }}>
+                                    <Grid item xs={12} sx={{maxHeight:'100px'}}>
+                                        <FormControl sx={{ verticalAlign: 'center', m: 1, width: '60ch' }} variant='outlined'>
+                                            <TextField
+                                            id='outlined-adornment-password'
+                                            type='password'
+                                            label='Password'
+                                            name='password'
+                                            value={formik.values.password}
+                                            onChange={formik.handleChange}
+                                            onBlur={formik.handleBlur}
+                                            error={formik.errors.password && formik.touched.password ? true : false}
+                                            helperText={formik.errors.password && <ErrorMessage name='password'/>}
+                                            />
+                                        </FormControl>
+                                    </Grid>
+                                    <Grid item xs={12} sx={{maxHeight:'100px'}}>
+                                        <FormControl sx={{ m: 1, width: '60ch' }} variant="outlined">
+                                            <TextField
+                                            id='outlined-adornment-confirmPassword'
+                                            type='password'
+                                            label='Confirm Password'
+                                            name='confirmPassword'
+                                            value={formik.values.confirmPassword}
+                                            onChange={formik.handleChange}
+                                            onBlur={formik.handleBlur}
+                                            error={formik.errors.confirmPassword && formik.touched.confirmPassword ? true : false}
+                                            helperText={formik.errors.confirmPassword && <ErrorMessage name='confirmPassword'/>}
+                                            />
+                                        </FormControl>
+                                    </Grid>
+                                    <Grid item xs={12}>
+                                        <Button disabled={formik.isSubmitting} variant='contained' type='submit'>Submit</Button>
+                                    </Grid>
                                 </Grid>
-                                <Grid item xs={12} sx={{maxHeight:'100px'}}>
-                                    <FormControl sx={{ m: 1, width: '60ch' }} variant="outlined">
-                                        <TextField
-                                        id='outlined-adornment-confirmPassword'
-                                        type='password'
-                                        label='Confirm Password'
-                                        name='confirmPassword'
-                                        value={formik.values.confirmPassword}
-                                        onChange={formik.handleChange}
-                                        onBlur={formik.handleBlur}
-                                        error={formik.errors.confirmPassword && formik.touched.confirmPassword ? true : false}
-                                        helperText={formik.errors.confirmPassword && <ErrorMessage name='confirmPassword'/>}
-                                        />
-                                    </FormControl>
-                                </Grid>
-                                <Grid item xs={12}>
-                                    <Button disabled={formik.isSubmitting} variant='contained' type='submit'>Submit</Button>
-                                </Grid>
-                            </Grid>
                             </Form>
                         </>)
                 }

--- a/frontend/landing-page/src/components/RegisterForm.tsx
+++ b/frontend/landing-page/src/components/RegisterForm.tsx
@@ -62,9 +62,8 @@ export const RegisterForm = () => {
         if (jwtResponse.data) {
             const header: AxiosRequestConfig = {headers: {Authorization: 'Bearer ' + jwtResponse.data}}
             const response: GenericResponse<UserModel>  = await _userApiClient.createUser(values as UserModel, header)
-            const header2: AxiosRequestConfig = {headers: {Authorization: 'Bearer ' + jwtResponse.data}}
             if (response.data) {
-                const emailResponse: GenericResponse<boolean> = await _emailApiClient.sendRegistrationEmail(response.data, header2)
+                const emailResponse: GenericResponse<boolean> = await _emailApiClient.sendRegistrationEmail(response.data, header)
                 if (emailResponse.data) {
                     setRegister({
                         isOpen: true,

--- a/frontend/landing-page/src/components/RegisterForm.tsx
+++ b/frontend/landing-page/src/components/RegisterForm.tsx
@@ -9,7 +9,6 @@ import LoginRegisterAlert from './LoginRegisterAlert'
 import { _userApiClient, _authenticationApiClient, _emailApiClient} from '../App'
 import { GenericResponse, UserModel } from '../api_views/IBaseApiClient'
 import { AxiosRequestConfig } from 'axios'
-import { GuestEmail, GuestPassword } from '../utils/Constants'
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import DatePickerField from './DatePickerField'
@@ -26,10 +25,10 @@ export const RegisterForm = () => {
         isOpen: false,
         isSuccess: false,
         message: ''
-      });
+      })
 
-    const maxDate = dayjs().subtract(18, "year").format("MM/DD/YYYY")
-    const minDate = dayjs().subtract(120, "year").format("MM/DD/YYYY")
+    const maxDate = dayjs().subtract(18, 'year').format('MM/DD/YYYY')
+    const minDate = dayjs().subtract(120, 'year').format('MM/DD/YYYY')
 
     const initialValues : RegisterFormValues = {
         firstName: '',
@@ -58,7 +57,7 @@ export const RegisterForm = () => {
             setSubmitting(false)
             return
         }
-        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(GuestEmail, GuestPassword)
+        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(process.env.REACT_APP_GUEST_EMAIL!, process.env.REACT_APP_GUEST_PASSWORD!)
         if (jwtResponse.data) {
             const header: AxiosRequestConfig = {headers: {Authorization: 'Bearer ' + jwtResponse.data}}
             const response: GenericResponse<UserModel>  = await _userApiClient.createUser(values as UserModel, header)

--- a/frontend/landing-page/src/components/ResetPasswordForm.tsx
+++ b/frontend/landing-page/src/components/ResetPasswordForm.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react'
+import { Formik, Form, ErrorMessage, FormikHelpers, FormikErrors } from 'formik'
+import * as Yup from 'yup'
+import { Button, FormControl, Grid,TextField } from '@mui/material'
+import { FormProperties } from '../utils/FormProperties'
+import LoginRegisterAlert from './LoginRegisterAlert'
+import { _userApiClient, _authenticationApiClient, _emailApiClient} from '../App'
+import { GenericResponse, UserModel } from '../api_views/IBaseApiClient'
+import { AxiosRequestConfig } from 'axios'
+import { GuestEmail, GuestPassword, Paths } from '../utils/Constants'
+import LoginHeader from './LoginHeader'
+
+export interface ResetPasswordFormValues {
+    email: string
+}
+
+export const ResetPasswordForm = () => {
+    const [passwordReset, setPasswordReset] = useState<FormProperties>({
+        isOpen: false,
+        isSuccess: false,
+        message: ''
+      });
+
+    const initialValues : ResetPasswordFormValues = {
+        email: ''
+    }
+
+    const onSubmit = async (values: ResetPasswordFormValues, { setSubmitting, resetForm, validateForm }: FormikHelpers<ResetPasswordFormValues>): Promise<void> => {
+        if (!values.email) {
+            setPasswordReset({
+                isOpen: true,
+                isSuccess: false,
+                message: 'Email Field Missing'
+            })
+            setSubmitting(false)
+            return
+        }
+        const errors: FormikErrors<ResetPasswordFormValues>  = await validateForm(values)
+        if (errors.email) {
+            setPasswordReset({
+                isOpen: true,
+                isSuccess: false,
+                message: 'Email is Invalid'
+            })
+            setSubmitting(false)
+            return
+        }
+        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(GuestEmail, GuestPassword)
+        if (jwtResponse.data) {
+            const header: AxiosRequestConfig = {headers: {Authorization: 'Bearer ' + jwtResponse.data}}
+            const response: GenericResponse<UserModel>  = await _userApiClient.getUser(values.email, header)
+            if (response.data) {
+                const emailResponse: GenericResponse<boolean> = await _emailApiClient.sendResetPasswordEmail(response.data, header)
+                if (emailResponse.data) {
+                    setPasswordReset({
+                        isOpen: true,
+                        isSuccess: true,
+                        message: `An Email Has Been Sent To ${response.data?.email}`
+                    })
+                    resetForm()
+                }
+                else {
+                    setPasswordReset({
+                        isOpen: true,
+                        isSuccess: false,
+                        message: `Email To ${response.data?.email} Failed to Send`
+                    })
+                }
+            }
+            else {
+                let resetPasswordProperties: FormProperties = {
+                    isOpen: true,
+                    isSuccess: false,
+                    message: response.message ? String(response.statusCode) : String(response.statusCode) + ': ' + response.message
+                }
+                if (response.statusCode === undefined) {
+                    resetPasswordProperties.message = 'Network Error'
+                    setPasswordReset(resetPasswordProperties)
+                }
+                else if (response.statusCode === 404) {
+                    resetPasswordProperties.message = 'No user with this email exists'
+                    setPasswordReset(resetPasswordProperties)
+                }
+                else {
+                    setPasswordReset(resetPasswordProperties)
+                }
+            }
+        }
+        else {
+            setPasswordReset({
+                isOpen: true,
+                isSuccess: false,
+                message: 'Internal Authentication Error'
+            })
+        }
+        setSubmitting(false)
+    }
+
+    const validation = Yup.object({
+        email: Yup.string().email('Invalid Email').required('Required')
+    })
+
+    return (
+        <>
+            <LoginHeader sideButton='Login' sideButtonPath={Paths['Login']}/>
+            <Formik initialValues={initialValues} validationSchema={validation} onSubmit={onSubmit}>
+            {
+                formik => (
+                <Form style={{display: 'flex', verticalAlign: 'middle', marginTop: '15px', flexDirection: 'column'}}autoComplete='off'>
+                    <Grid container spacing={5} direction='column' justifyContent='center' alignItems='center' sx={{ minHeight: '100vh' }}>
+                        <Grid item xs={12} sx={{maxHeight:'100px'}}>
+                            <FormControl sx={{ verticalAlign: 'center', m: 1, width: '60ch' }} variant='outlined'>
+                                <TextField
+                                    type='email'
+                                    label='Email'
+                                    name='email'
+                                    value={formik.values.email}
+                                    onChange={formik.handleChange}
+                                    onBlur={formik.handleBlur}
+                                    error={formik.errors.email && formik.touched.email ? true : false}
+                                    helperText={formik.errors.email && <ErrorMessage name='email'/>}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <Button disabled={formik.isSubmitting} variant='contained' type='submit'>Submit</Button>
+                        </Grid>
+                    </Grid>
+                </Form>)   
+            }
+            </Formik>
+            <LoginRegisterAlert login={passwordReset} setLogin={setPasswordReset} />
+        </>
+    )
+}
+
+export default ResetPasswordForm

--- a/frontend/landing-page/src/components/ResetPasswordForm.tsx
+++ b/frontend/landing-page/src/components/ResetPasswordForm.tsx
@@ -7,7 +7,7 @@ import LoginRegisterAlert from './LoginRegisterAlert'
 import { _userApiClient, _authenticationApiClient, _emailApiClient} from '../App'
 import { GenericResponse, UserModel } from '../api_views/IBaseApiClient'
 import { AxiosRequestConfig } from 'axios'
-import { GuestEmail, GuestPassword, Paths } from '../utils/Constants'
+import { Paths } from '../utils/Constants'
 import LoginHeader from './LoginHeader'
 
 export interface ResetPasswordFormValues {
@@ -45,7 +45,7 @@ export const ResetPasswordForm = () => {
             setSubmitting(false)
             return
         }
-        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(GuestEmail, GuestPassword)
+        const jwtResponse: GenericResponse<string> = await _authenticationApiClient.login(process.env.REACT_APP_GUEST_EMAIL!, process.env.REACT_APP_GUEST_PASSWORD!)
         if (jwtResponse.data) {
             const header: AxiosRequestConfig = {headers: {Authorization: 'Bearer ' + jwtResponse.data}}
             const response: GenericResponse<UserModel>  = await _userApiClient.getUser(values.email, header)

--- a/frontend/landing-page/src/index.tsx
+++ b/frontend/landing-page/src/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
+import React from 'react'
+import './index.css'
+import App from './App'
+import { createRoot } from 'react-dom/client'
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root')!)
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
+  </React.StrictMode>
+)

--- a/frontend/landing-page/src/pages/LoginPage.tsx
+++ b/frontend/landing-page/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, FormControl, Grid, IconButton, InputAdornment, InputLabel, OutlinedInput, TextField, Typography} from '@mui/material'
+import { Button, FormControl, Grid, IconButton, InputAdornment, InputLabel, Link, OutlinedInput, TextField, Typography} from '@mui/material'
 import Visibility from '@mui/icons-material/Visibility'
 import VisibilityOff from '@mui/icons-material/VisibilityOff'
 import React from 'react'
@@ -112,17 +112,23 @@ export const LoginPage = () => {
                 onChange={onChangePassword} />
             </FormControl>
           </Grid>
-          <Grid item xs={3}>
-            <Button
-              type="submit"
-              variant="contained"
-              color="primary"
-              onClick={handleClickLogin}
-            >
-              <Typography variant="h5" display="block" align="center">
-                Log in
-              </Typography>
-            </Button>
+          <Grid item container direction='row' alignItems='center' justifyContent='center' xs={11}>
+            <Grid item xs={4.75}></Grid>
+            <Grid item xs={1.5}>
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                onClick={handleClickLogin}
+              >
+                <Typography variant="h5" display="block" align="center">
+                  Log in
+                </Typography>
+              </Button>
+            </Grid>
+            <Grid item xs={4.75}>
+              <Link display='flex' alignContent='start' justifyContent='start' href='http://localhost:3000/resetPassword'>Reset Password</Link>
+            </Grid>
             <LoginRegisterAlert login={login} setLogin={setLogin} />
           </Grid>
         </Grid>

--- a/frontend/landing-page/src/pages/LoginPage.tsx
+++ b/frontend/landing-page/src/pages/LoginPage.tsx
@@ -29,7 +29,7 @@ export const LoginPage = () => {
         setLogin({
           isOpen: true,
           isSuccess: false,
-          message: "An email or password has not been entered yet"
+          message: 'An email or password has not been entered yet'
         })
         return
       }
@@ -38,7 +38,7 @@ export const LoginPage = () => {
         setLogin({
           isOpen: true,
           isSuccess: true,
-          message: "User Has Successfully Logged In!"
+          message: 'User Has Successfully Logged In!'
         })
       }
       else {
@@ -48,11 +48,11 @@ export const LoginPage = () => {
           message: String(response.statusCode)
         }
         if (response.statusCode === undefined) {
-          loginProperties.message = "Network Error"
+          loginProperties.message = 'Network Error'
           setLogin(loginProperties)
         }
         else if (response.statusCode === 400) {
-          loginProperties.message = "Invalid Email or Password"
+          loginProperties.message = 'Invalid Email or Password'
           setLogin(loginProperties)
         }
         else {
@@ -79,36 +79,36 @@ export const LoginPage = () => {
         <Grid
           container
           spacing={3}
-          direction="column"
-          alignItems="center"
-          justifyContent="center"
+          direction='column'
+          alignItems='center'
+          justifyContent='center'
           sx={{ minHeight: '100vh' }}
         >
           <Grid item xs={10}>
             <TextField
               style={{ width: '60ch' }}
-              label="Email"
-              variant="outlined"
+              label='Email'
+              variant='outlined'
               value={email}
               onChange={onChangeEmail} />
           </Grid>
           <Grid item xs={5}>
-            <FormControl sx={{ m: 1, width: '60ch' }} variant="outlined">
-              <InputLabel htmlFor="outlined-adornment-password">Password</InputLabel>
+            <FormControl sx={{ m: 1, width: '60ch' }} variant='outlined'>
+              <InputLabel htmlFor='outlined-adornment-password'>Password</InputLabel>
               <OutlinedInput
-                id="outlined-adornment-password"
+                id='outlined-adornment-password'
                 type={showPassword ? 'text' : 'password'}
-                endAdornment={<InputAdornment position="end">
+                endAdornment={<InputAdornment position='end'>
                   <IconButton
-                    aria-label="toggle password visibility"
+                    aria-label='toggle password visibility'
                     onClick={handleClickShowPassword}
                     onMouseDown={handleMouseDownPassword}
-                    edge="end"
+                    edge='end'
                   >
                     {showPassword ? <VisibilityOff /> : <Visibility />}
                   </IconButton>
                 </InputAdornment>}
-                label="Password"
+                label='Password'
                 onChange={onChangePassword} />
             </FormControl>
           </Grid>
@@ -116,12 +116,12 @@ export const LoginPage = () => {
             <Grid item xs={4.75}></Grid>
             <Grid item xs={1.5}>
               <Button
-                type="submit"
-                variant="contained"
-                color="primary"
+                type='submit'
+                variant='contained'
+                color='primary'
                 onClick={handleClickLogin}
               >
-                <Typography variant="h5" display="block" align="center">
+                <Typography variant='h5' display='block' align='center'>
                   Log in
                 </Typography>
               </Button>

--- a/frontend/landing-page/src/pages/ResetPasswordPage.tsx
+++ b/frontend/landing-page/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import ResetPasswordForm from '../components/ResetPasswordForm'
+
+export const ResetPasswordPage = () => {
+
+    return (
+        <div>
+            <ResetPasswordForm/>
+        </div>
+    )}
+
+export default ResetPasswordPage

--- a/frontend/landing-page/src/utils/Constants.ts
+++ b/frontend/landing-page/src/utils/Constants.ts
@@ -1,8 +1,6 @@
 export const AuthEndpoint = "https://localhost:7208/auth/"
 export const UserEndpoint = "https://localhost:7208/user/"
 export const EmailEndpoint = "https://localhost:7208/email/"
-export const GuestEmail = "guest@instaconnect.com"
-export const GuestPassword = "test123"
 
 export const Paths = {
     "Login" : "/",

--- a/frontend/landing-page/tsconfig.json
+++ b/frontend/landing-page/tsconfig.json
@@ -22,5 +22,5 @@
   },
   "include": [
     "src"
-  ],
+, "src/App.tsx"  ],
 }


### PR DESCRIPTION
Created a new reset password page at `/resetPassword`. This should work similar to the registration [age where it will use email verification to confirm it is you and then bring you to the `/setPassword` page. Formik, Yup and React are all used for this new page.

**Endpoint**
`POST` /Email/ResetPassword created from Email Service in the backend to send the specific reset password email

![ResetPassword](https://github.com/philipmeneghini/InstaConnect/assets/63440066/b7120bce-293f-4bb1-b43d-dff91d2e4287)

**Testing**

- Make sure you cannot reset the password of a user that does not exist int he database
- Check that the link to the reset password page in the login page works correctly
- Confirm that an email is sent when the application says so and that the link redirects as it is suppose to
- Try logging in after successfully changing the password with the new password to confirm that the database was updated correctly.