### PR TITLE
Lazy Loading For Home Page

### DIFF
--- a/backend/Authorization/CommentDeleteHandler.cs
+++ b/backend/Authorization/CommentDeleteHandler.cs
@@ -31,7 +31,7 @@ namespace Backend.Authorization
             List<string> ids = query.Value.Where(v => !string.IsNullOrWhiteSpace(v)).ToList();
             try
             {
-                List<CommentModel> comments = _commentService.GetComments(ids);
+                List<CommentModel> comments = _commentService.GetComments(ids, null);
                 if (comments.Count == 0)
                 {
                     context.Fail();

--- a/backend/Authorization/ContentDeleteHandler.cs
+++ b/backend/Authorization/ContentDeleteHandler.cs
@@ -31,7 +31,7 @@ namespace Backend.Authorization
             List<string> ids = query.Value.Where(v => !string.IsNullOrWhiteSpace(v)).ToList();
             try
             {
-                List<ContentModel> contents = _contentService.GetContents(ids);
+                List<ContentModel> contents = _contentService.GetContents(ids, null);
                 if (contents.Count == 0)
                 {
                     context.Fail();

--- a/backend/Controllers/CommentController.cs
+++ b/backend/Controllers/CommentController.cs
@@ -24,9 +24,12 @@ namespace InstaConnect.Controllers
         }
 
         [HttpGet("Comments")]
-        public async Task<ActionResult<List<CommentModel>>> GetContents([FromQuery] string? contentId)
+        public async Task<ActionResult<List<CommentModel>>> GetComments([FromQuery] List<string>? ids, 
+                                                                        [FromQuery] List<string>? contentIds, 
+                                                                        [FromQuery] int? index = null, 
+                                                                        [FromQuery] int? limit = null)
         {
-            return await _commentService.GetCommentsAsync(contentId);
+            return await _commentService.GetCommentsAsync(ids, contentIds, index, limit);
         }
 
         [Authorize(Policy = "CommentPolicy")]

--- a/backend/Controllers/ContentController.cs
+++ b/backend/Controllers/ContentController.cs
@@ -25,9 +25,11 @@ namespace InstaConnect.Controllers
 
         [HttpGet("Contents")]
         public async Task<ActionResult<List<ContentModel>>> GetContents([FromQuery] List<string>? ids, 
-                                                                        [FromQuery] List<string>? emails)
+                                                                        [FromQuery] List<string>? emails,
+                                                                        [FromQuery] int? index,
+                                                                        [FromQuery] int? limit)
         {
-            return await _contentService.GetContentsAsync(ids, emails);
+            return await _contentService.GetContentsAsync(ids, emails, index, limit);
         }
 
         [Authorize(Policy = "ContentPolicy")]

--- a/backend/Controllers/ContentController.cs
+++ b/backend/Controllers/ContentController.cs
@@ -24,9 +24,10 @@ namespace InstaConnect.Controllers
         }
 
         [HttpGet("Contents")]
-        public async Task<ActionResult<List<ContentModel>>> GetContents([FromQuery] string? email)
+        public async Task<ActionResult<List<ContentModel>>> GetContents([FromQuery] List<string>? ids, 
+                                                                        [FromQuery] List<string>? emails)
         {
-            return await _contentService.GetContentsAsync(email);
+            return await _contentService.GetContentsAsync(ids, emails);
         }
 
         [Authorize(Policy = "ContentPolicy")]

--- a/backend/Models/LazyLoadModel.cs
+++ b/backend/Models/LazyLoadModel.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Backend.Models
+{
+    public class LazyLoadModel
+    {
+        [Required]
+        public int Index { get; set; } = 0;
+
+        [Required]
+        public int Limit { get; set; }
+
+        public LazyLoadModel(int? index, int limit)
+        {
+            Index = index ?? 0;
+            Limit = limit;
+        }
+    }
+}

--- a/backend/Services/ContentService.cs
+++ b/backend/Services/ContentService.cs
@@ -61,56 +61,76 @@ namespace Backend.Services
             return content;
         }
 
-        public async Task<List<ContentModel>> GetContentsAsync(string? email)
+        public async Task<List<ContentModel>> GetContentsAsync(List<string>? ids, List<string>? emails)
         {
-            if (string.IsNullOrEmpty(email)) throw new InstaBadRequestException(ApplicationConstants.EmailEmpty);
-            var validationModel = new ContentEmailValidationModel(email);
-            var validationResult = _emailContentValidator.Validate(validationModel, options => options.IncludeRuleSets(ApplicationConstants.Get));
-            ThrowExceptions(validationResult);
-
-            var filter = Builders<ContentModel>.Filter.Eq(ApplicationConstants.Email, email);
-            var contents = await GetModelsAsync(filter);
-
-            if (contents.Count == 0)
-                throw new InstaNotFoundException(ApplicationConstants.NoContentFound);
-            contents.ForEach(content => content.MediaUrl = _mediaService.GeneratePresignedUrl(GenerateKey(content.Email, content.Id, content.MediaType), ApplicationConstants.S3BucketName, GET, content.MediaType));
-
-            return contents;
-        }
-
-        public List<ContentModel> GetContents(string? email)
-        {
-            if (string.IsNullOrEmpty(email)) throw new InstaBadRequestException(ApplicationConstants.EmailEmpty);
-            var validationModel = new ContentEmailValidationModel(email);
-            var validationResult = _emailContentValidator.Validate(validationModel, options => options.IncludeRuleSets(ApplicationConstants.Get));
-            ThrowExceptions(validationResult);
-
-            var filter = Builders<ContentModel>.Filter.Eq(ApplicationConstants.Email, email);
-            var contents = GetModels(filter);
-
-            if (contents.Count == 0)
-                throw new InstaNotFoundException(ApplicationConstants.NoContentFound);
-            contents.ForEach(content => content.MediaUrl = _mediaService.GeneratePresignedUrl(GenerateKey(content.Email, content.Id, content.MediaType), ApplicationConstants.S3BucketName, GET, content.MediaType));
-
-            return contents;
-        }
-
-        public List<ContentModel> GetContents(List<string> ids)
-        {
-            if (ids == null || ids.Count == 0) throw new InstaBadRequestException(ApplicationConstants.IdsEmpty);
-            var filter = Builders<ContentModel>.Filter.Eq(ApplicationConstants.Id, ids.FirstOrDefault());
-            bool firstId = true;
-            foreach (var id in ids)
+            if ((emails == null || emails.Count == 0)
+                && (ids == null || ids.Count == 0))
             {
-                var validationResult = _deleteGetContentValidator.Validate(new ContentIdValidationModel(id), Options => Options.IncludeRuleSets(ApplicationConstants.Delete));
-                ThrowExceptions(validationResult);
-
-                if (firstId)
-                    filter |= Builders<ContentModel>.Filter.Eq(ApplicationConstants.Id, id);
-                firstId = false;
+                throw new InstaBadRequestException(ApplicationConstants.EmailIdEmpty);
             }
 
-            var contents = GetModels(filter);
+            List<FilterDefinition<ContentModel>> filters = new List<FilterDefinition<ContentModel>>() { };
+            if (emails != null && emails.Count != 0)
+            {
+                foreach (var email in emails)
+                {
+                    var validationModel = new ContentEmailValidationModel(email);
+                    var validationResult = _emailContentValidator.Validate(validationModel, options => options.IncludeRuleSets(ApplicationConstants.Get));
+                    ThrowExceptions(validationResult);
+
+                    filters.Add(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Email, email));
+                }
+            }
+            if (ids != null && ids.Count != 0)
+            {
+                foreach (var id in ids)
+                {
+                    filters.Add(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Id, id));
+                }
+            }
+
+            var aggregatedFilter = Builders<ContentModel>.Filter.Or(filters);
+ 
+            var contents = await GetModelsAsync(aggregatedFilter);
+
+            if (contents.Count == 0)
+                throw new InstaNotFoundException(ApplicationConstants.NoContentFound);
+            contents.ForEach(content => content.MediaUrl = _mediaService.GeneratePresignedUrl(GenerateKey(content.Email, content.Id, content.MediaType), ApplicationConstants.S3BucketName, GET, content.MediaType));
+
+            return contents;
+        }
+
+        public List<ContentModel> GetContents(List<string>? ids, List<string>? emails)
+        {
+            if ((emails == null || emails.Count == 0)
+                && (ids == null || ids.Count == 0))
+            {
+                throw new InstaBadRequestException(ApplicationConstants.EmailIdEmpty);
+            }
+
+            FilterDefinition<ContentModel>[] filters = new FilterDefinition<ContentModel>[] { };
+            if (emails != null && emails.Count != 0)
+            {
+                foreach (var email in emails)
+                {
+                    var validationModel = new ContentEmailValidationModel(email);
+                    var validationResult = _emailContentValidator.Validate(validationModel, options => options.IncludeRuleSets(ApplicationConstants.Get));
+                    ThrowExceptions(validationResult);
+
+                    filters.Append(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Email, email));
+                }
+            }
+            else if (ids != null && ids.Count != 0)
+            {
+                foreach (var id in ids)
+                {
+                    filters.Append(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Id, id));
+                }
+            }
+
+            var aggregatedFilter = Builders<ContentModel>.Filter.Or(filters);
+
+            var contents = GetModels(aggregatedFilter);
 
             if (contents.Count == 0)
                 throw new InstaNotFoundException(ApplicationConstants.NoContentFound);

--- a/backend/Services/ContentService.cs
+++ b/backend/Services/ContentService.cs
@@ -112,7 +112,7 @@ namespace Backend.Services
                 throw new InstaBadRequestException(ApplicationConstants.EmailIdEmpty);
             }
 
-            FilterDefinition<ContentModel>[] filters = new FilterDefinition<ContentModel>[] { };
+            List<FilterDefinition<ContentModel>> filters = new List<FilterDefinition<ContentModel>>() { };
             if (emails != null && emails.Count != 0)
             {
                 foreach (var email in emails)
@@ -121,14 +121,14 @@ namespace Backend.Services
                     var validationResult = _emailContentValidator.Validate(validationModel, options => options.IncludeRuleSets(ApplicationConstants.Get));
                     ThrowExceptions(validationResult);
 
-                    filters.Append(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Email, email));
+                    filters.Add(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Email, email));
                 }
             }
             else if (ids != null && ids.Count != 0)
             {
                 foreach (var id in ids)
                 {
-                    filters.Append(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Id, id));
+                    filters.Add(Builders<ContentModel>.Filter.Eq(ApplicationConstants.Id, id));
                 }
             }
 

--- a/backend/Services/ICommentService.cs
+++ b/backend/Services/ICommentService.cs
@@ -7,9 +7,8 @@ namespace Backend.Services.Interfaces
         public CommentModel GetComment(string? id);
         public Task<CommentModel> GetCommentAsync(string? id);
 
-        public List<CommentModel> GetComments(string? contentId);
-        public List<CommentModel> GetComments(List<string>? ids);
-        public Task<List<CommentModel>> GetCommentsAsync(string? contentId);
+        public List<CommentModel> GetComments(List<string>? ids, List<string>? contentIds, int? index = null, int? limit = null);
+        public Task<List<CommentModel>> GetCommentsAsync(List<string>? ids, List<string>? contentIds, int? index = null, int? limit = null);
 
         public CommentModel CreateComment(CommentModel? comment);
         public Task<CommentModel> CreateCommentAsync(CommentModel? comment);

--- a/backend/Services/IContentService.cs
+++ b/backend/Services/IContentService.cs
@@ -7,8 +7,8 @@ namespace Backend.Services.Interfaces
         public ContentModel GetContent(string? id);
         public Task<ContentModel> GetContentAsync(string? id);
 
-        public List<ContentModel> GetContents(List<string>? ids, List<string>? email);
-        public Task<List<ContentModel>> GetContentsAsync(List<string>? ids, List<string>? email);
+        public List<ContentModel> GetContents(List<string>? ids, List<string>? email, int? index = null, int? limit = null);
+        public Task<List<ContentModel>> GetContentsAsync(List<string>? ids, List<string>? email, int? index = null, int? limit = null);
 
         public ContentModel CreateContent(ContentModel? content);
         public Task<ContentModel> CreateContentAsync(ContentModel? content);

--- a/backend/Services/IContentService.cs
+++ b/backend/Services/IContentService.cs
@@ -7,9 +7,8 @@ namespace Backend.Services.Interfaces
         public ContentModel GetContent(string? id);
         public Task<ContentModel> GetContentAsync(string? id);
 
-        public List<ContentModel> GetContents(string? email);
-        public List<ContentModel> GetContents(List<string> ids);
-        public Task<List<ContentModel>> GetContentsAsync(string? email);
+        public List<ContentModel> GetContents(List<string>? ids, List<string>? email);
+        public Task<List<ContentModel>> GetContentsAsync(List<string>? ids, List<string>? email);
 
         public ContentModel CreateContent(ContentModel? content);
         public Task<ContentModel> CreateContentAsync(ContentModel? content);

--- a/backend/Util/ApplicationConstants.cs
+++ b/backend/Util/ApplicationConstants.cs
@@ -47,6 +47,7 @@ namespace Util.Constants
         static public readonly string CommentEmpty = "no comment passed in";
         static public readonly string IdsEmpty = "no ids passed in";
         static public readonly string EmailEmpty = "no email passed in";
+        static public readonly string EmailIdEmpty = "no email or id passed in";
         static public readonly string MediaTypeEmpty = "cannot leave mediaType empty";
         static public readonly string MediaTypeNotValid = "media type is not valid";
         static public readonly string ContentIdEmpty = "no content id passed in";

--- a/backend/Util/ApplicationConstants.cs
+++ b/backend/Util/ApplicationConstants.cs
@@ -51,6 +51,7 @@ namespace Util.Constants
         static public readonly string MediaTypeEmpty = "cannot leave mediaType empty";
         static public readonly string MediaTypeNotValid = "media type is not valid";
         static public readonly string ContentIdEmpty = "no content id passed in";
+        static public readonly string ContentCommentIdsEmpty = "no content or comment id is passed in";
         static public readonly string ContentIdNotHexadecimal = "content id is not a hexadecimal";
         static public readonly string NoUsersFound = "no users found";
         static public readonly string NoContentFound = "no content found";

--- a/frontend/main/package-lock.json
+++ b/frontend/main/package-lock.json
@@ -29,6 +29,7 @@
         "formik": "^2.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.8.2",
         "react-router-dom": "^6.11.2",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.11",
@@ -15067,6 +15068,20 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.8.2.tgz",
+      "integrity": "sha512-901naEiiZmse3p+AmtbQ3NL9xx+gQ8TXLiGDc+8GiE3JKJkNV3vP737aGuWTAXBA+1QqxPrDDE+fIEgYpGDlrQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/frontend/main/package.json
+++ b/frontend/main/package.json
@@ -24,6 +24,7 @@
     "formik": "^2.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.8.2",
     "react-router-dom": "^6.11.2",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.11",

--- a/frontend/main/src/api/Client.ts
+++ b/frontend/main/src/api/Client.ts
@@ -10,7 +10,7 @@
 
 import axios, { AxiosError } from 'axios';
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
-import { AuthorizedApiBase } from './AuthorizedApiBase'
+import { AuthorizedApiBase } from './AuthorizedApiBase';
 
 export class Client extends AuthorizedApiBase {
     private instance: AxiosInstance;
@@ -953,15 +953,20 @@ export class Client extends AuthorizedApiBase {
     }
 
     /**
-     * @param email (optional) 
+     * @param ids (optional) 
+     * @param emails (optional) 
      * @return Success
      */
-    contentsGET(email?: string | undefined, cancelToken?: CancelToken | undefined): Promise<ContentModel[]> {
+    contentsGET(ids?: string[] | undefined, emails?: string[] | undefined, cancelToken?: CancelToken | undefined): Promise<ContentModel[]> {
         let url_ = this.baseUrl + "/Content/Contents?";
-        if (email === null)
-            throw new Error("The parameter 'email' cannot be null.");
-        else if (email !== undefined)
-            url_ += "email=" + encodeURIComponent("" + email) + "&";
+        if (ids === null)
+            throw new Error("The parameter 'ids' cannot be null.");
+        else if (ids !== undefined)
+            ids && ids.forEach(item => { url_ += "ids=" + encodeURIComponent("" + item) + "&"; });
+        if (emails === null)
+            throw new Error("The parameter 'emails' cannot be null.");
+        else if (emails !== undefined)
+            emails && emails.forEach(item => { url_ += "emails=" + encodeURIComponent("" + item) + "&"; });
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: AxiosRequestConfig = {

--- a/frontend/main/src/api/Client.ts
+++ b/frontend/main/src/api/Client.ts
@@ -489,15 +489,30 @@ export class Client extends AuthorizedApiBase {
     }
 
     /**
-     * @param contentId (optional) 
+     * @param ids (optional) 
+     * @param contentIds (optional) 
+     * @param index (optional) 
+     * @param limit (optional) 
      * @return Success
      */
-    commentsGET(contentId?: string | undefined, cancelToken?: CancelToken | undefined): Promise<CommentModel[]> {
+    commentsGET(ids?: string[] | undefined, contentIds?: string[] | undefined, index?: number | undefined, limit?: number | undefined, cancelToken?: CancelToken | undefined): Promise<CommentModel[]> {
         let url_ = this.baseUrl + "/Comment/Comments?";
-        if (contentId === null)
-            throw new Error("The parameter 'contentId' cannot be null.");
-        else if (contentId !== undefined)
-            url_ += "contentId=" + encodeURIComponent("" + contentId) + "&";
+        if (ids === null)
+            throw new Error("The parameter 'ids' cannot be null.");
+        else if (ids !== undefined)
+            ids && ids.forEach(item => { url_ += "ids=" + encodeURIComponent("" + item) + "&"; });
+        if (contentIds === null)
+            throw new Error("The parameter 'contentIds' cannot be null.");
+        else if (contentIds !== undefined)
+            contentIds && contentIds.forEach(item => { url_ += "contentIds=" + encodeURIComponent("" + item) + "&"; });
+        if (index === null)
+            throw new Error("The parameter 'index' cannot be null.");
+        else if (index !== undefined)
+            url_ += "index=" + encodeURIComponent("" + index) + "&";
+        if (limit === null)
+            throw new Error("The parameter 'limit' cannot be null.");
+        else if (limit !== undefined)
+            url_ += "limit=" + encodeURIComponent("" + limit) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: AxiosRequestConfig = {

--- a/frontend/main/src/api/Client.ts
+++ b/frontend/main/src/api/Client.ts
@@ -955,9 +955,11 @@ export class Client extends AuthorizedApiBase {
     /**
      * @param ids (optional) 
      * @param emails (optional) 
+     * @param index (optional) 
+     * @param limit (optional) 
      * @return Success
      */
-    contentsGET(ids?: string[] | undefined, emails?: string[] | undefined, cancelToken?: CancelToken | undefined): Promise<ContentModel[]> {
+    contentsGET(ids?: string[] | undefined, emails?: string[] | undefined, index?: number | undefined, limit?: number | undefined, cancelToken?: CancelToken | undefined): Promise<ContentModel[]> {
         let url_ = this.baseUrl + "/Content/Contents?";
         if (ids === null)
             throw new Error("The parameter 'ids' cannot be null.");
@@ -967,6 +969,14 @@ export class Client extends AuthorizedApiBase {
             throw new Error("The parameter 'emails' cannot be null.");
         else if (emails !== undefined)
             emails && emails.forEach(item => { url_ += "emails=" + encodeURIComponent("" + item) + "&"; });
+        if (index === null)
+            throw new Error("The parameter 'index' cannot be null.");
+        else if (index !== undefined)
+            url_ += "index=" + encodeURIComponent("" + index) + "&";
+        if (limit === null)
+            throw new Error("The parameter 'limit' cannot be null.");
+        else if (limit !== undefined)
+            url_ += "limit=" + encodeURIComponent("" + limit) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: AxiosRequestConfig = {

--- a/frontend/main/src/components/home-page/PostContentBox.tsx
+++ b/frontend/main/src/components/home-page/PostContentBox.tsx
@@ -70,7 +70,7 @@ export const PostContentBox = ( props: PostContentProps ) => {
     useEffect(() => {
         const getComments = async (content: ContentModel) => {
             try {
-                const response = await _apiClient.commentsGET(content.id)
+                const response = await _apiClient.commentsGET(undefined, [ content.id as string ])
                 setComments(response)
             }
             catch {

--- a/frontend/main/src/pages/main-page/HomePage.tsx
+++ b/frontend/main/src/pages/main-page/HomePage.tsx
@@ -9,25 +9,43 @@ import AddIcon from '@mui/icons-material/Add'
 import CreatePostBox from '../../components/home-page/CreatePostBox'
 import { UserContext } from '../../components/context-provider/UserProvider'
 import { useInView } from 'react-intersection-observer'
+import { makeStyles } from 'tss-react/mui'
 
-const fabStyling = {
-    position: 'fixed',
-    bottom: 10,
-    right: 8,
-}
+const useStyles = makeStyles()(
+    () => ({
+        fabStyling: {
+            position: 'fixed',
+            bottom: 10,
+            right: 8,
+        },
+        modalBox: { 
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: '40vw',
+            maxHeight: '90vh',
+            bgcolor: 'whitesmoke',
+            border: '1px solid #000',
+            p: '2vh',
+            overflowY: 'auto',
+        },
+        contentsBox: {
+            display: 'flex', 
+            flexDirection: 'column', 
+            alignItems: 'center', 
+            marginTop: '10vh'
+        },
+        contentsPaper: {
+            margin: '2vh 0', 
+            width: '40vw', 
+            padding: '2% 0 1%'
+        },
+        progressBar: {
+            marginTop: '20vh'
+        }
 
-const postBoxStyle = {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: '40vw',
-    maxHeight: '90vh',
-    bgcolor: 'whitesmoke',
-    border: '1px solid #000',
-    p: '2vh',
-    overflowY: 'auto',
-}
+  }))
 
 export interface UserContents {
     user: UserModel
@@ -103,6 +121,14 @@ export const HomePage = () => {
         getFollowing()
     }, [user])
 
+    const {
+        fabStyling,
+        modalBox,
+        contentsBox,
+        contentsPaper,
+        progressBar
+    } = useStyles().classes
+
     const handleCreatePost = () => { setCreatePostOpen(true) }
     const handleCreatePostClose = () => { setCreatePostOpen(false) }
 
@@ -111,21 +137,21 @@ export const HomePage = () => {
         <div>
             <Header user={user}/>
             {contents.length !== 0 && contentLoadMessage === null ? 
-            <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', marginTop: '10vh'}}>
+            <Box className={contentsBox}>
                 {contents.map( (userContent, index) => (
                     (index === contents.length -1) ?
-                        <Paper ref={ref} key={userContent?.content?.id} elevation={24} sx={{margin: '2vh 0', width: '40vw', padding: '2% 0 1%'}}>
+                        <Paper ref={ref} key={userContent?.content?.id} className={contentsPaper} elevation={24}>
                             <PostContentBox key={userContent?.content?.id} userContent={userContent} user={user}/>
                         </Paper>
                     :
-                    <Paper key={userContent?.content?.id} elevation={24} sx={{margin: '2vh 0', width: '40vw', padding: '2% 0 1%'}}>
+                    <Paper key={userContent?.content?.id} className={contentsPaper} elevation={24}>
                         <PostContentBox key={userContent?.content?.id} userContent={userContent} user={user}/>
                     </Paper>
                 ))}
             </Box> :
-            <CircularProgress sx={{marginTop: '20vh'}}/>}
+            <CircularProgress className={progressBar}/>}
             <Tooltip title='Add Post'>
-                <Fab onClick={handleCreatePost} sx={fabStyling} color='primary' aria-label='add'>
+                <Fab onClick={handleCreatePost} className={fabStyling} color='primary' aria-label='add'>
                     <AddIcon />
                 </Fab>
             </Tooltip>
@@ -135,7 +161,7 @@ export const HomePage = () => {
             aria-labelledby='modal-modal-title'
             aria-describedby='modal-modal-description'
             >
-                <Box sx={postBoxStyle}>
+                <Box className={modalBox}>
                     <CreatePostBox handleClose={handleCreatePostClose}/>
                 </Box>
             </Modal>

--- a/frontend/main/src/pages/main-page/ProfilePage.tsx
+++ b/frontend/main/src/pages/main-page/ProfilePage.tsx
@@ -53,7 +53,7 @@ export const ProfilePage = () => {
                         profile = user
                     }
                     setProfile(profile)
-                    const contents = await _apiClient.contentsGET(profile?.email)
+                    const contents = await _apiClient.contentsGET(undefined, [ profile?.email ])
                     const orderedContents = contents.sort(dateCreatedDescendingContents)
                     setContents(orderedContents)
                 }
@@ -77,7 +77,7 @@ export const ProfilePage = () => {
     const handleOpen = (content: ContentModel) => { setContent(content) }
     const handleClose = async () => { 
         if (profile) {
-            const contents = await _apiClient.contentsGET(profile?.email)
+            const contents = await _apiClient.contentsGET(undefined, [ profile?.email ])
             setContents(contents)
         }
         setContent(null)
@@ -114,7 +114,7 @@ export const ProfilePage = () => {
     const handleCreatePost = () => { setCreatePostOpen(true) }
     const handleCreatePostClose = async () => {
         if (profile) {
-            const contents = await _apiClient.contentsGET(profile?.email)
+            const contents = await _apiClient.contentsGET(undefined, [ profile?.email ])
             setContents(contents)
         }
         setCreatePostOpen(false) 


### PR DESCRIPTION
**Summary**
Currently the home page load is extremely slow due to the way it is calling the api and iterating through all users following and all their associated contents. In this PR I created more effective endpoints to get all users that a person is following and then lazy load the contents from the backend from these users. Since we are calling these endpoints once in the `useEffect` hook there is a dramatic speed improvement. As we scroll we can see new backend requests are made to retrieve more posts that users following may have made.

![HomePageLazyLoad](https://github.com/philipmeneghini/InstaConnect/assets/63440066/c5c3d523-0020-4e83-84ea-cdc998c7b981)

This will be the first of a series of PRs that will add more lazy loading throughout the application. Next I will lazily load comments and likes on each post.

**Testing**

- Make sure that new content is called as scrolling down the homepage
- content should be ordered by date created
- verify new endpoints work for users and contents. Try passing an index and limit parameter to only call in a small subsect of the data
