### PR TITLE
Authorization Enhanced for PUT Requests

### DIFF
--- a/backend/Authorization/CommentPolicies/CommentCreateHandler.cs
+++ b/backend/Authorization/CommentPolicies/CommentCreateHandler.cs
@@ -23,8 +23,9 @@ namespace Backend.Authorization.CommentPolicies
                 return Task.CompletedTask;
             }
 
-            List<CommentModel> inputs;
-            _authorizationHelper.TryGetBody(out inputs);
+            var body = Task.Run(() => _authorizationHelper.TryGetBodyAsync<CommentModel>());
+            body.Wait();
+            var inputs = body.Result;
             string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
             foreach (var input in inputs)
             {

--- a/backend/Authorization/CommentPolicies/CommentUpdateHandler.cs
+++ b/backend/Authorization/CommentPolicies/CommentUpdateHandler.cs
@@ -1,0 +1,53 @@
+﻿using Amazon.SimpleEmail.Model;
+using Backend.Authorization.Helpers;
+using Backend.Models;
+using Backend.Services.Interfaces;
+using Backend.Util;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Backend.Authorization.CommentPolicies
+{
+    public class CommentUpdateHandler : AuthorizationHandler<CommentUpdateRequirement>
+    {
+        private readonly IAuthorizationHelper _authorizationHelper;
+        private readonly ICommentService _commentService;
+        private readonly ICommentHelper _commentHelper;
+
+        public CommentUpdateHandler(IAuthorizationHelper authorizationHelper, 
+                                    ICommentService commentService,
+                                    ICommentHelper commentHelper)
+        {
+            _authorizationHelper = authorizationHelper;
+            _commentService = commentService;
+            _commentHelper = commentHelper;
+        }
+
+        protected override Task HandleRequirementAsync
+            (AuthorizationHandlerContext context, CommentUpdateRequirement requirement)
+        {
+            var claim = _authorizationHelper.GetRole();
+            if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
+            {
+                context.Succeed(requirement);
+                return Task.CompletedTask;
+            }
+
+            List<CommentModel> inputs;
+            _authorizationHelper.TryGetBody(out inputs);
+            string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
+            List<CommentModel> comments = _commentService.GetComments(inputs.Where(i => i != null && i.Email != null && i.Email != loggedInEmail)
+                                                                            .Select(b => b.Id).ToList() as List<string>, null);
+            foreach (var comment in comments)
+            {
+                CommentModel? input = inputs.FirstOrDefault(b => b.Id.Equals(comment.Id, StringComparison.OrdinalIgnoreCase));
+                if (comment == null || input == null || !_commentHelper.CompareLikes(loggedInEmail, input, comment))
+                {
+                    context.Fail();
+                    return Task.CompletedTask;
+                }
+            }
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/backend/Authorization/CommentPolicies/CommentUpdateHandler.cs
+++ b/backend/Authorization/CommentPolicies/CommentUpdateHandler.cs
@@ -36,8 +36,9 @@ namespace Backend.Authorization.CommentPolicies
             inputs.Wait();
             List<CommentModel> body = inputs.Result;
             string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
-            List<CommentModel> comments = _commentService.GetComments(body.Where(i => i != null && i.Email != null && i.Email != loggedInEmail)
-                                                                            .Select(b => b.Id).ToList() as List<string>, null);
+            List<string> ids = body.Where(i => i != null && i.Email != null && i.Email != loggedInEmail)
+                                                                            .Select(b => b.Id).ToList() as List<string>;
+            List<CommentModel> comments = ids.Count > 0 ? _commentService.GetComments(ids, null) : new List<CommentModel>();
             foreach (var comment in comments)
             {
                 CommentModel? input = body.FirstOrDefault(b => b.Id.Equals(comment.Id, StringComparison.OrdinalIgnoreCase));

--- a/backend/Authorization/CommentPolicies/CommentUpdateHandler.cs
+++ b/backend/Authorization/CommentPolicies/CommentUpdateHandler.cs
@@ -1,5 +1,4 @@
-﻿using Amazon.SimpleEmail.Model;
-using Backend.Authorization.Helpers;
+﻿using Backend.Authorization.Helpers;
 using Backend.Models;
 using Backend.Services.Interfaces;
 using Backend.Util;

--- a/backend/Authorization/CommentPolicies/CommentUpdateRequirement.cs
+++ b/backend/Authorization/CommentPolicies/CommentUpdateRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Backend.Authorization.CommentPolicies
+{
+    public class CommentUpdateRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/backend/Authorization/ContentPolicies/ContentCreateHandler.cs
+++ b/backend/Authorization/ContentPolicies/ContentCreateHandler.cs
@@ -24,8 +24,9 @@ namespace Backend.Authorization.ContentPolicies
                 return Task.CompletedTask;
             }
 
-            List<ContentModel> body;
-            _authorizationHelper.TryGetBody(out body);
+            var inputs = Task.Run(() => _authorizationHelper.TryGetBodyAsync<ContentModel>());
+            inputs.Wait();
+            var body = inputs.Result;
             string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
             foreach (var input in body)
             {

--- a/backend/Authorization/ContentPolicies/ContentCreateHandler.cs
+++ b/backend/Authorization/ContentPolicies/ContentCreateHandler.cs
@@ -1,38 +1,42 @@
-﻿using Backend.Models;
+﻿using Backend.Authorization.Helpers;
+using Backend.Models;
 using Backend.Util;
 using Microsoft.AspNetCore.Authorization;
-using Util.Constants;
 
 namespace Backend.Authorization.ContentPolicies
 {
 
     public class ContentCreateHandler : AuthorizationHandler<ContentCreateRequirement>
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        public ContentCreateHandler(IHttpContextAccessor httpContextAccessor)
+        private readonly IAuthorizationHelper _authorizationHelper;
+
+        public ContentCreateHandler(IAuthorizationHelper authorizationHelper, IHttpContextAccessor httpContextAccessor)
         {
-            _httpContextAccessor = httpContextAccessor;
+            _authorizationHelper = authorizationHelper;
         }
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, ContentCreateRequirement requirement)
         {
-            var claim = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
+            var claim = _authorizationHelper.GetRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }
-            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
-            httpRequest.EnableBuffering();
-            var input = httpRequest.ReadFromJsonAsync<ContentModel>().Result;
-            var email = input?.Email;
-            string loggedInEmail = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
-            if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
-                || string.IsNullOrEmpty(email)
-                || string.IsNullOrEmpty(loggedInEmail))
+
+            List<ContentModel> body;
+            _authorizationHelper.TryGetBody(out body);
+            string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
+            foreach (var input in body)
             {
-                context.Fail();
-                return Task.CompletedTask;
+                string email = input.Email;
+                if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
+               || string.IsNullOrEmpty(email)
+               || string.IsNullOrEmpty(loggedInEmail))
+                {
+                    context.Fail();
+                    return Task.CompletedTask;
+                }
             }
             context.Succeed(requirement);
             return Task.CompletedTask;

--- a/backend/Authorization/ContentPolicies/ContentUpdateHandler.cs
+++ b/backend/Authorization/ContentPolicies/ContentUpdateHandler.cs
@@ -1,0 +1,52 @@
+﻿using Backend.Authorization.Helpers;
+using Backend.Models;
+using Backend.Services.Interfaces;
+using Backend.Util;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Backend.Authorization.ContentPolicies
+{
+    public class ContentUpdateHandler : AuthorizationHandler<ContentUpdateRequirement>
+    {
+        private readonly IAuthorizationHelper _authorizationHelper;
+        private readonly IContentHelper _contentHelper;
+        private readonly IContentService _contentService;
+
+        public ContentUpdateHandler(IAuthorizationHelper authorizationHelper, 
+                                    IContentHelper contentHelper, 
+                                    IContentService contentService)
+        {
+            _authorizationHelper = authorizationHelper;
+            _contentHelper = contentHelper;
+            _contentService = contentService;
+        }
+        protected override Task HandleRequirementAsync
+            (AuthorizationHandlerContext context, ContentUpdateRequirement requirement)
+        {
+            var claim = _authorizationHelper.GetRole();
+            if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
+            {
+                context.Succeed(requirement);
+                return Task.CompletedTask;
+            }
+
+            List<ContentModel> body;
+            _authorizationHelper.TryGetBody(out body);
+            string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
+            List<ContentModel> contents = _contentService.GetContents(body.Where(b => b != null && b.Email != null && b.Email != loggedInEmail)
+                                                                          .Select(b => b.Id).ToList() as List<string>, null);
+            foreach (var content in contents)
+            {
+                ContentModel? input = body.FirstOrDefault(b => b.Id.Equals(content.Id, StringComparison.OrdinalIgnoreCase));
+                if (content == null || input == null || !_contentHelper.CompareLikes(loggedInEmail, input, content))
+                {
+                    context.Fail();
+                    return Task.CompletedTask;
+                }
+            }
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+    }
+}
+

--- a/backend/Authorization/ContentPolicies/ContentUpdateHandler.cs
+++ b/backend/Authorization/ContentPolicies/ContentUpdateHandler.cs
@@ -30,14 +30,14 @@ namespace Backend.Authorization.ContentPolicies
                 return Task.CompletedTask;
             }
 
-            List<ContentModel> body;
-            _authorizationHelper.TryGetBody(out body);
+            var body = Task.Run(() => _authorizationHelper.TryGetBodyAsync<ContentModel>());
+            body.Wait();
             string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
-            List<ContentModel> contents = _contentService.GetContents(body.Where(b => b != null && b.Email != null && b.Email != loggedInEmail)
+            List<ContentModel> contents = _contentService.GetContents(body.Result.Where(b => b != null && b.Email != null && b.Email != loggedInEmail)
                                                                           .Select(b => b.Id).ToList() as List<string>, null);
             foreach (var content in contents)
             {
-                ContentModel? input = body.FirstOrDefault(b => b.Id.Equals(content.Id, StringComparison.OrdinalIgnoreCase));
+                ContentModel? input = body.Result.FirstOrDefault(b => b.Id.Equals(content.Id, StringComparison.OrdinalIgnoreCase));
                 if (content == null || input == null || !_contentHelper.CompareLikes(loggedInEmail, input, content))
                 {
                     context.Fail();

--- a/backend/Authorization/ContentPolicies/ContentUpdateRequirement.cs
+++ b/backend/Authorization/ContentPolicies/ContentUpdateRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Backend.Authorization.ContentPolicies
+{
+    public class ContentUpdateRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/backend/Authorization/Helpers/AuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/AuthorizationHelper.cs
@@ -4,7 +4,7 @@ using Util.Constants;
 
 namespace Backend.Authorization.Helpers
 {
-    public class AuthorizationHelper<T> : IAuthorizationHelper<T> where T : IInstaModel
+    public class AuthorizationHelper : IAuthorizationHelper
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
 
@@ -13,12 +13,12 @@ namespace Backend.Authorization.Helpers
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public Claim? RetrieveRole()
+        public Claim? GetRole()
         {
             return _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
         }
 
-        public string? RetrieveLoggedInEmail()
+        public string? GetLoggedInEmail()
         {
             return _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
         }
@@ -39,7 +39,7 @@ namespace Backend.Authorization.Helpers
             return query.Count > 0;
         }
 
-        public bool TryGetBody(out List<T> body)
+        public bool TryGetBody<T>(out List<T> body) where T : IInstaModel
         {
             body = new List<T>();
             HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;

--- a/backend/Authorization/Helpers/AuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/AuthorizationHelper.cs
@@ -1,0 +1,59 @@
+﻿using Backend.Models;
+using System.Security.Claims;
+using Util.Constants;
+
+namespace Backend.Authorization.Helpers
+{
+    public class AuthorizationHelper<T> : IAuthorizationHelper<T> where T : IInstaModel
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public AuthorizationHelper(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public Claim? RetrieveRole()
+        {
+            return _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public string? RetrieveLoggedInEmail()
+        {
+            return _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
+        }
+
+        public bool TryGetQueries(string queryName, out List<string> query)
+        {
+            query = new List<string>();
+            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
+            httpRequest.EnableBuffering();
+            var list = httpRequest.Query.FirstOrDefault(q => q.Key.Equals(queryName, StringComparison.OrdinalIgnoreCase)).Value;
+
+            foreach (var val in list)
+            {
+                if (!string.IsNullOrWhiteSpace(val))
+                    query.Add(val);
+            }
+
+            return query.Count > 0;
+        }
+
+        public bool TryGetBody(out List<T> body)
+        {
+            body = new List<T>();
+            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
+            httpRequest.EnableBuffering();
+            var inputs = httpRequest.ReadFromJsonAsync<List<T>>();
+            if (inputs.IsCompletedSuccessfully && inputs.Result != null)
+                body.AddRange(inputs.Result);
+
+            var input = httpRequest.ReadFromJsonAsync<T>();
+            if (input.IsCompletedSuccessfully && input.Result != null)
+                body.Add(input.Result);
+
+            httpRequest.Body.Position = 0;
+            return body.Count > 0;
+        }
+    }
+}

--- a/backend/Authorization/Helpers/AuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/AuthorizationHelper.cs
@@ -55,5 +55,32 @@ namespace Backend.Authorization.Helpers
             httpRequest.Body.Position = 0;
             return body.Count > 0;
         }
+
+        public async Task<List<T>> TryGetBodyAsync<T>() where T : IInstaModel
+        {
+            var body = new List<T>();
+            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
+            httpRequest.EnableBuffering();
+            try
+            {
+                var inputs = await httpRequest.ReadFromJsonAsync<List<T>>();
+                if (inputs != null)
+                    body.AddRange(inputs);
+            }
+            catch { }
+
+            httpRequest.Body.Position = 0;
+
+            try
+            {
+                var input = await httpRequest.ReadFromJsonAsync<T>();
+                if (input != null)
+                    body.Add(input);
+            }
+            catch { }
+
+            httpRequest.Body.Position = 0;
+            return body;
+        }
     }
 }

--- a/backend/Authorization/Helpers/AuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/AuthorizationHelper.cs
@@ -39,23 +39,6 @@ namespace Backend.Authorization.Helpers
             return query.Count > 0;
         }
 
-        public bool TryGetBody<T>(out List<T> body) where T : IInstaModel
-        {
-            body = new List<T>();
-            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
-            httpRequest.EnableBuffering();
-            var inputs = httpRequest.ReadFromJsonAsync<List<T>>();
-            if (inputs.IsCompletedSuccessfully && inputs.Result != null)
-                body.AddRange(inputs.Result);
-
-            var input = httpRequest.ReadFromJsonAsync<T>();
-            if (input.IsCompletedSuccessfully && input.Result != null)
-                body.Add(input.Result);
-
-            httpRequest.Body.Position = 0;
-            return body.Count > 0;
-        }
-
         public async Task<List<T>> TryGetBodyAsync<T>() where T : IInstaModel
         {
             var body = new List<T>();

--- a/backend/Authorization/Helpers/IAuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/IAuthorizationHelper.cs
@@ -1,0 +1,16 @@
+﻿using Backend.Models;
+using System.Security.Claims;
+
+namespace Backend.Authorization.Helpers
+{
+    public interface IAuthorizationHelper<T> where T : IInstaModel
+    {
+        public Claim? RetrieveRole();
+
+        public string? RetrieveLoggedInEmail();
+
+        public bool TryGetBody(out List<T> body);
+
+        public bool TryGetQueries(string queryName, out List<string> query);
+    }
+}

--- a/backend/Authorization/Helpers/IAuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/IAuthorizationHelper.cs
@@ -3,13 +3,13 @@ using System.Security.Claims;
 
 namespace Backend.Authorization.Helpers
 {
-    public interface IAuthorizationHelper<T> where T : IInstaModel
+    public interface IAuthorizationHelper
     {
-        public Claim? RetrieveRole();
+        public Claim? GetRole();
 
-        public string? RetrieveLoggedInEmail();
+        public string? GetLoggedInEmail();
 
-        public bool TryGetBody(out List<T> body);
+        public bool TryGetBody<T>(out List<T> body) where T : IInstaModel;
 
         public bool TryGetQueries(string queryName, out List<string> query);
     }

--- a/backend/Authorization/Helpers/IAuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/IAuthorizationHelper.cs
@@ -11,6 +11,8 @@ namespace Backend.Authorization.Helpers
 
         public bool TryGetBody<T>(out List<T> body) where T : IInstaModel;
 
+        public Task<List<T>> TryGetBodyAsync<T>() where T : IInstaModel;
+
         public bool TryGetQueries(string queryName, out List<string> query);
     }
 }

--- a/backend/Authorization/Helpers/IAuthorizationHelper.cs
+++ b/backend/Authorization/Helpers/IAuthorizationHelper.cs
@@ -9,8 +9,6 @@ namespace Backend.Authorization.Helpers
 
         public string? GetLoggedInEmail();
 
-        public bool TryGetBody<T>(out List<T> body) where T : IInstaModel;
-
         public Task<List<T>> TryGetBodyAsync<T>() where T : IInstaModel;
 
         public bool TryGetQueries(string queryName, out List<string> query);

--- a/backend/Authorization/NotificationPolicies/NotificationHandler.cs
+++ b/backend/Authorization/NotificationPolicies/NotificationHandler.cs
@@ -1,4 +1,5 @@
-﻿using Backend.Models;
+﻿using Backend.Authorization.Helpers;
+using Backend.Models;
 using Backend.Services;
 using Backend.Util;
 using Microsoft.AspNetCore.Authorization;
@@ -8,30 +9,32 @@ namespace Backend.Authorization.NotificationPolicies
 {
     public class NotificationHandler : AuthorizationHandler<NotificationRequirement>
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IAuthorizationHelper _authorizationHelper;
         private readonly INotificationService _notificationService;
 
-        public NotificationHandler(IHttpContextAccessor httpContextAccessor, INotificationService notificationService)
+        public NotificationHandler(IHttpContextAccessor httpContextAccessor, IAuthorizationHelper authorizationHelper, INotificationService notificationService)
         {
-            _httpContextAccessor = httpContextAccessor;
+            _authorizationHelper = authorizationHelper;
             _notificationService = notificationService;
         }
+
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, NotificationRequirement requirement)
         {
-            var claim = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
+            var claim = _authorizationHelper.GetRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }
-            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
-            httpRequest.EnableBuffering();
-            var id = httpRequest.Query.FirstOrDefault(q => q.Key.Equals(ApplicationConstants.Id, StringComparison.OrdinalIgnoreCase)).Value.FirstOrDefault();
+
+            List<string> ids;
+            _authorizationHelper.TryGetQueries(ApplicationConstants.Id, out ids);
+            var id = ids.FirstOrDefault();
             NotificationModel notification = _notificationService.GetNotification(id);
             var email = notification.Reciever;
 
-            string loggedInEmail = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
+            string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
             if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
             || string.IsNullOrEmpty(email)
             || string.IsNullOrEmpty(loggedInEmail))

--- a/backend/Authorization/NotificationPolicies/NotificationsHandler.cs
+++ b/backend/Authorization/NotificationPolicies/NotificationsHandler.cs
@@ -7,6 +7,7 @@ namespace Backend.Authorization.NotificationPolicies
     public class NotificationsHandler : AuthorizationHandler<NotificationsRequirement>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+
         public NotificationsHandler(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;

--- a/backend/Authorization/UserPolicies/UserDeleteHandler.cs
+++ b/backend/Authorization/UserPolicies/UserDeleteHandler.cs
@@ -10,9 +10,9 @@ namespace Backend.Authorization.UserPolicies
     public class UserDeleteHandler : AuthorizationHandler<UserDeleteRequirement>
     {
 
-        private readonly IAuthorizationHelper<UserModel> _authorizationHelper;
+        private readonly IAuthorizationHelper _authorizationHelper;
 
-        public UserDeleteHandler(IAuthorizationHelper<UserModel> authorizationHelper)
+        public UserDeleteHandler(IAuthorizationHelper authorizationHelper)
         {
             _authorizationHelper = authorizationHelper;
         }
@@ -20,7 +20,7 @@ namespace Backend.Authorization.UserPolicies
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, UserDeleteRequirement requirement)
         {
-            var claim = _authorizationHelper.RetrieveRole();
+            var claim = _authorizationHelper.GetRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
@@ -33,7 +33,7 @@ namespace Backend.Authorization.UserPolicies
                 context.Fail();
                 return Task.CompletedTask;
             }
-            string loggedInEmail = _authorizationHelper.RetrieveLoggedInEmail() ?? string.Empty;
+            string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
             
             foreach (var value in query)
             {

--- a/backend/Authorization/UserPolicies/UserHandler.cs
+++ b/backend/Authorization/UserPolicies/UserHandler.cs
@@ -23,12 +23,10 @@ namespace Backend.Authorization
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }
-            List<UserModel> users;
-            if (!_authorizationHelper.TryGetBody(out users))
-            {
-                context.Fail();
-                return Task.CompletedTask;
-            }
+
+            var res = Task.Run(() => _authorizationHelper.TryGetBodyAsync<UserModel>());
+            res.Wait();
+            List<UserModel> users = res.Result;
             foreach(var user in users)
             {
                 var email = user.Email;

--- a/backend/Authorization/UserPolicies/UserHandler.cs
+++ b/backend/Authorization/UserPolicies/UserHandler.cs
@@ -1,39 +1,45 @@
-﻿using Backend.Authorization.UserPolicies;
+﻿using Backend.Authorization.Helpers;
+using Backend.Authorization.UserPolicies;
 using Backend.Models;
 using Backend.Util;
 using Microsoft.AspNetCore.Authorization;
-using Util.Constants;
 
 namespace Backend.Authorization
 {
 
     public class UserHandler : AuthorizationHandler<UserRequirement>
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        public UserHandler(IHttpContextAccessor httpContextAccessor)
+        private readonly IAuthorizationHelper<UserModel> _authorizationHelper;
+        public UserHandler(IAuthorizationHelper<UserModel> httpContextAccessor)
         {
-            _httpContextAccessor = httpContextAccessor;
+            _authorizationHelper = httpContextAccessor;
         }
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, UserRequirement requirement)
         {
-            var claim = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
+            var claim = _authorizationHelper.RetrieveRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }
-            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
-            httpRequest.EnableBuffering();
-            var input = httpRequest.ReadFromJsonAsync<UserModel>().Result;
-            var email = input?.Email;
-            string loggedInEmail = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
-            if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
-                || string.IsNullOrEmpty(email)
-                || string.IsNullOrEmpty(loggedInEmail))
+            List<UserModel> users;
+            if (!_authorizationHelper.TryGetBody(out users))
             {
                 context.Fail();
                 return Task.CompletedTask;
+            }
+            foreach(var user in users)
+            {
+                var email = user.Email;
+                string loggedInEmail = _authorizationHelper.RetrieveLoggedInEmail() ?? string.Empty;
+                if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
+                    || string.IsNullOrEmpty(email)
+                    || string.IsNullOrEmpty(loggedInEmail))
+                {
+                    context.Fail();
+                    return Task.CompletedTask;
+                }
             }
             context.Succeed(requirement);
             return Task.CompletedTask;

--- a/backend/Authorization/UserPolicies/UserHandler.cs
+++ b/backend/Authorization/UserPolicies/UserHandler.cs
@@ -9,15 +9,15 @@ namespace Backend.Authorization
 
     public class UserHandler : AuthorizationHandler<UserRequirement>
     {
-        private readonly IAuthorizationHelper<UserModel> _authorizationHelper;
-        public UserHandler(IAuthorizationHelper<UserModel> httpContextAccessor)
+        private readonly IAuthorizationHelper _authorizationHelper;
+        public UserHandler(IAuthorizationHelper httpContextAccessor)
         {
             _authorizationHelper = httpContextAccessor;
         }
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, UserRequirement requirement)
         {
-            var claim = _authorizationHelper.RetrieveRole();
+            var claim = _authorizationHelper.GetRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
@@ -32,7 +32,7 @@ namespace Backend.Authorization
             foreach(var user in users)
             {
                 var email = user.Email;
-                string loggedInEmail = _authorizationHelper.RetrieveLoggedInEmail() ?? string.Empty;
+                string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
                 if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
                     || string.IsNullOrEmpty(email)
                     || string.IsNullOrEmpty(loggedInEmail))

--- a/backend/Authorization/UserPolicies/UserUpdateHandler.cs
+++ b/backend/Authorization/UserPolicies/UserUpdateHandler.cs
@@ -37,14 +37,19 @@ namespace Backend.Authorization
             res.Wait();
             var body = res.Result;
             string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
-            foreach (var input in body) 
+            List<string> emails  = body.Where(b => b != null && b.Email != null && b.Email != loggedInEmail)
+                                    .Select(b => b.Email).ToList() as List<string>;
+
+            List<UserModel> users = emails.Count > 0 ? _userService.GetUsers(emails) : new List<UserModel>();
+
+            foreach (var user in users) 
             {
-                var email = input?.Email;
+                var input = body.FirstOrDefault(b => b.Id.Equals(user.Id, StringComparison.OrdinalIgnoreCase));
+                var email = user.Email;
                 if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
                     || string.IsNullOrEmpty(email)
                     || string.IsNullOrEmpty(loggedInEmail))
                 {
-                    UserModel user = _userService.GetUser(email);
 
                     if (input == null || !_userHelper.CompareFollowers(loggedInEmail, input, user))
                     {

--- a/backend/Authorization/UserPolicies/UserUpdateHandler.cs
+++ b/backend/Authorization/UserPolicies/UserUpdateHandler.cs
@@ -33,12 +33,9 @@ namespace Backend.Authorization
                 return Task.CompletedTask;
             }
 
-            List<UserModel> body;
-            if (!_authorizationHelper.TryGetBody(out body))
-            {
-                context.Fail();
-                return Task.CompletedTask;
-            }
+            var res = Task.Run(() => _authorizationHelper.TryGetBodyAsync<UserModel>());
+            res.Wait();
+            var body = res.Result;
             string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
             foreach (var input in body) 
             {

--- a/backend/Authorization/UserPolicies/UserUpdateHandler.cs
+++ b/backend/Authorization/UserPolicies/UserUpdateHandler.cs
@@ -1,22 +1,24 @@
-﻿using Backend.Authorization.UserPolicies;
+﻿using Backend.Authorization.Helpers;
+using Backend.Authorization.UserPolicies;
 using Backend.Models;
 using Backend.Services.Interfaces;
 using Backend.Util;
 using Microsoft.AspNetCore.Authorization;
-using Util.Constants;
 
 namespace Backend.Authorization
 {
 
     public class UserUpdateHandler : AuthorizationHandler<UserUpdateRequirement>
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IAuthorizationHelper<UserModel> _authorizationHelper;
         private readonly IUserService _userService;
         private readonly IUserHelper _userHelper;
 
-        public UserUpdateHandler(IHttpContextAccessor httpContextAccessor, IUserService userService, IUserHelper userHelper)
+        public UserUpdateHandler(IAuthorizationHelper<UserModel> authorizationHelper, 
+                                 IUserService userService, 
+                                 IUserHelper userHelper)
         {
-            _httpContextAccessor = httpContextAccessor;
+            _authorizationHelper = authorizationHelper;
             _userService = userService;
             _userHelper = userHelper;
         }
@@ -24,27 +26,34 @@ namespace Backend.Authorization
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, UserUpdateRequirement requirement)
         {
-            var claim = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
+            var claim = _authorizationHelper.RetrieveRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }
-            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
-            httpRequest.EnableBuffering();
-            var input = httpRequest.ReadFromJsonAsync<UserModel>().Result;
-            var email = input?.Email;
-            string loggedInEmail = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
-            if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
-                || string.IsNullOrEmpty(email)
-                || string.IsNullOrEmpty(loggedInEmail))
-            {
-                UserModel user = _userService.GetUser(email);
 
-                if (input == null || !_userHelper.CompareFollowers(loggedInEmail, input, user))
+            List<UserModel> body;
+            if (!_authorizationHelper.TryGetBody(out body))
+            {
+                context.Fail();
+                return Task.CompletedTask;
+            }
+            string loggedInEmail = _authorizationHelper.RetrieveLoggedInEmail() ?? string.Empty;
+            foreach (var input in body) 
+            {
+                var email = input?.Email;
+                if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
+                    || string.IsNullOrEmpty(email)
+                    || string.IsNullOrEmpty(loggedInEmail))
                 {
-                    context.Fail();
-                    return Task.CompletedTask;
+                    UserModel user = _userService.GetUser(email);
+
+                    if (input == null || !_userHelper.CompareFollowers(loggedInEmail, input, user))
+                    {
+                        context.Fail();
+                        return Task.CompletedTask;
+                    }
                 }
             }
             context.Succeed(requirement);

--- a/backend/Authorization/UserPolicies/UserUpdateHandler.cs
+++ b/backend/Authorization/UserPolicies/UserUpdateHandler.cs
@@ -1,0 +1,54 @@
+﻿using Backend.Authorization.UserPolicies;
+using Backend.Models;
+using Backend.Services.Interfaces;
+using Backend.Util;
+using Microsoft.AspNetCore.Authorization;
+using Util.Constants;
+
+namespace Backend.Authorization
+{
+
+    public class UserUpdateHandler : AuthorizationHandler<UserUpdateRequirement>
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IUserService _userService;
+        private readonly IUserHelper _userHelper;
+
+        public UserUpdateHandler(IHttpContextAccessor httpContextAccessor, IUserService userService, IUserHelper userHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _userService = userService;
+            _userHelper = userHelper;
+        }
+
+        protected override Task HandleRequirementAsync
+            (AuthorizationHandlerContext context, UserUpdateRequirement requirement)
+        {
+            var claim = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Role, StringComparison.OrdinalIgnoreCase));
+            if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
+            {
+                context.Succeed(requirement);
+                return Task.CompletedTask;
+            }
+            HttpRequest httpRequest = _httpContextAccessor.HttpContext!.Request;
+            httpRequest.EnableBuffering();
+            var input = httpRequest.ReadFromJsonAsync<UserModel>().Result;
+            var email = input?.Email;
+            string loggedInEmail = _httpContextAccessor.HttpContext!.User.Claims.FirstOrDefault(c => c.Type.Equals(ApplicationConstants.Email, StringComparison.OrdinalIgnoreCase))!.Value;
+            if (!loggedInEmail.Equals(email, StringComparison.OrdinalIgnoreCase)
+                || string.IsNullOrEmpty(email)
+                || string.IsNullOrEmpty(loggedInEmail))
+            {
+                UserModel user = _userService.GetUser(email);
+
+                if (input == null || !_userHelper.CompareFollowers(loggedInEmail, input, user))
+                {
+                    context.Fail();
+                    return Task.CompletedTask;
+                }
+            }
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/backend/Authorization/UserPolicies/UserUpdateHandler.cs
+++ b/backend/Authorization/UserPolicies/UserUpdateHandler.cs
@@ -10,11 +10,11 @@ namespace Backend.Authorization
 
     public class UserUpdateHandler : AuthorizationHandler<UserUpdateRequirement>
     {
-        private readonly IAuthorizationHelper<UserModel> _authorizationHelper;
+        private readonly IAuthorizationHelper _authorizationHelper;
         private readonly IUserService _userService;
         private readonly IUserHelper _userHelper;
 
-        public UserUpdateHandler(IAuthorizationHelper<UserModel> authorizationHelper, 
+        public UserUpdateHandler(IAuthorizationHelper authorizationHelper, 
                                  IUserService userService, 
                                  IUserHelper userHelper)
         {
@@ -26,7 +26,7 @@ namespace Backend.Authorization
         protected override Task HandleRequirementAsync
             (AuthorizationHandlerContext context, UserUpdateRequirement requirement)
         {
-            var claim = _authorizationHelper.RetrieveRole();
+            var claim = _authorizationHelper.GetRole();
             if (claim != null && claim.Value.Equals(Role.Administrator.ToString()))
             {
                 context.Succeed(requirement);
@@ -39,7 +39,7 @@ namespace Backend.Authorization
                 context.Fail();
                 return Task.CompletedTask;
             }
-            string loggedInEmail = _authorizationHelper.RetrieveLoggedInEmail() ?? string.Empty;
+            string loggedInEmail = _authorizationHelper.GetLoggedInEmail() ?? string.Empty;
             foreach (var input in body) 
             {
                 var email = input?.Email;

--- a/backend/Authorization/UserPolicies/UserUpdateRequirement.cs
+++ b/backend/Authorization/UserPolicies/UserUpdateRequirement.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace Backend.Authorization.UserPolicies
+{
+    public class UserUpdateRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/backend/Controllers/CommentController.cs
+++ b/backend/Controllers/CommentController.cs
@@ -46,12 +46,14 @@ namespace InstaConnect.Controllers
             return await _commentService.CreateCommentsAsync(newComments);
         }
 
+        [Authorize(Policy = "CommentUpdatePolicy")]
         [HttpPut("Comment")]
         public async Task<ActionResult<CommentModel>> PutComment([FromBody]CommentModel? newComment)
         {
             return await _commentService.UpdateCommentAsync(newComment);
         }
 
+        [Authorize(Policy = "CommentUpdatePolicy")]
         [HttpPut("Comments")]
         public async Task<ActionResult<List<CommentModel>>> PutComments([FromBody] List<CommentModel>? newComments)
         {

--- a/backend/Controllers/ContentController.cs
+++ b/backend/Controllers/ContentController.cs
@@ -46,12 +46,14 @@ namespace InstaConnect.Controllers
             return await _contentService.CreateContentsAsync(newContents);
         }
 
+        [Authorize(Policy = "ContentUpdatePolicy")]
         [HttpPut("Content")]
         public async Task<ActionResult<ContentModel>> PutContent([FromBody]ContentModel? newContent)
         {
             return await _contentService.UpdateContentAsync(newContent);
         }
 
+        [Authorize(Policy = "ContentUpdatePolicy")]
         [HttpPut("Contents")]
         public async Task<ActionResult<List<ContentModel>>> PutContents([FromBody] List<ContentModel>? newContents)
         {

--- a/backend/Controllers/UserController.cs
+++ b/backend/Controllers/UserController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace InstaConnect.Controllers
 {
-    [Authorize]
+    //[Authorize]
     [ApiController]
     [Route("[controller]")]
     public class UserController : ControllerBase
@@ -43,6 +43,7 @@ namespace InstaConnect.Controllers
             return await _userService.CreateUsersAsync(newUsers);
         }
 
+        [Authorize(Policy = "UserUpdatePolicy")]
         [HttpPut("User")]
         public async Task<ActionResult<UserModel>> PutUser([FromBody] UserModel? newUser)
         {

--- a/backend/Controllers/UserController.cs
+++ b/backend/Controllers/UserController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace InstaConnect.Controllers
 {
-    //[Authorize]
+    [Authorize]
     [ApiController]
     [Route("[controller]")]
     public class UserController : ControllerBase
@@ -50,6 +50,7 @@ namespace InstaConnect.Controllers
             return await _userService.UpdateUserAsync(newUser);
         }
 
+        [Authorize(Policy = "UserUpdatePolicy")]
         [HttpPut("Users")]
         public async Task<ActionResult<List<UserModel>>> PutUsers([FromBody] List<UserModel>? newUsers)
         {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddSingleton<IUserHelper, UserHelper>();
 builder.Services.AddSingleton<IContentHelper, ContentHelper>();
+builder.Services.AddSingleton<ICommentHelper, CommentHelper>();
 builder.Services.AddSingleton<IValidator<UserEmailValidationModel>, UserEmailValidator>();
 builder.Services.AddSingleton<IValidator<UserModel>, UserModelValidator>();
 builder.Services.AddSingleton<IValidator<ContentIdValidationModel>, ContentIdValidator>();
@@ -59,10 +60,12 @@ builder.Services.AddSingleton<IAuthorizationHandler, CommentCreateHandler>();
 builder.Services.AddSingleton<IAuthorizationHandler, UserHandler>();
 builder.Services.AddSingleton<IAuthorizationHandler, UserDeleteHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, UserUpdateHandler>();
+builder.Services.AddScoped<IAuthorizationHandler, ContentUpdateHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, NotificationHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, NotificationsHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, ContentDeleteHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, CommentDeleteHandler>();
+builder.Services.AddScoped<IAuthorizationHandler, CommentUpdateHandler>();
 builder.Services.AddScoped<INotificationHub, NotificationHub>();
 builder.Services.AddScoped<ISearchService<UserModel>, UserService>();
 builder.Services.AddScoped<ISearchService<ContentModel>, ContentService>();
@@ -105,6 +108,16 @@ builder.Services.AddAuthorization(options =>
     {
         policy.RequireClaim(ApplicationConstants.Role, ApplicationConstants.AdminUserRoleList);
         policy.Requirements.Add(new UserUpdateRequirement());
+    });
+    options.AddPolicy("ContentUpdatePolicy", policy =>
+    {
+        policy.RequireClaim(ApplicationConstants.Role, ApplicationConstants.AdminUserRoleList);
+        policy.Requirements.Add(new ContentUpdateRequirement());
+    });
+    options.AddPolicy("CommentUpdatePolicy", policy =>
+    {
+        policy.RequireClaim(ApplicationConstants.Role, ApplicationConstants.AdminUserRoleList);
+        policy.Requirements.Add(new CommentUpdateRequirement());
     });
     options.AddPolicy("ContentCreatePolicy", policy =>
     {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -18,6 +18,7 @@ using Backend.Authorization.ContentPolicies;
 using Backend.Authorization.UserPolicies;
 using Backend.Validators.NotificationValidators;
 using Backend.Authorization.NotificationPolicies;
+using Backend.Util;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -39,6 +40,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddSingleton<IUserHelper, UserHelper>();
 builder.Services.AddSingleton<IValidator<UserEmailValidationModel>, UserEmailValidator>();
 builder.Services.AddSingleton<IValidator<UserModel>, UserModelValidator>();
 builder.Services.AddSingleton<IValidator<ContentIdValidationModel>, ContentIdValidator>();
@@ -54,6 +56,7 @@ builder.Services.AddSingleton<IAuthorizationHandler, ContentCreateHandler>();
 builder.Services.AddSingleton<IAuthorizationHandler, CommentCreateHandler>();
 builder.Services.AddSingleton<IAuthorizationHandler, UserHandler>();
 builder.Services.AddSingleton<IAuthorizationHandler, UserDeleteHandler>();
+builder.Services.AddScoped<IAuthorizationHandler, UserUpdateHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, NotificationHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, NotificationsHandler>();
 builder.Services.AddScoped<IAuthorizationHandler, ContentDeleteHandler>();
@@ -94,6 +97,11 @@ builder.Services.AddAuthorization(options =>
     {
         policy.RequireClaim(ApplicationConstants.Role, ApplicationConstants.AdminUserRoleList);
         policy.Requirements.Add(new UserRequirement());
+    });
+    options.AddPolicy("UserUpdatePolicy", policy =>
+    {
+        policy.RequireClaim(ApplicationConstants.Role, ApplicationConstants.AdminUserRoleList);
+        policy.Requirements.Add(new UserUpdateRequirement());
     });
     options.AddPolicy("ContentCreatePolicy", policy =>
     {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -19,6 +19,7 @@ using Backend.Authorization.UserPolicies;
 using Backend.Validators.NotificationValidators;
 using Backend.Authorization.NotificationPolicies;
 using Backend.Util;
+using Backend.Authorization.Helpers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -74,6 +75,7 @@ builder.Services.AddScoped<ICommentService, CommentService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();
 builder.Services.AddTransient<IHttpContextAccessor, HttpContextAccessor>();
+builder.Services.AddTransient<IAuthorizationHelper<UserModel>, AuthorizationHelper<UserModel>>();
 
 builder.Services.AddCors(p => p.AddPolicy(ApplicationConstants.CorsPolicy, build =>
 {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddSingleton<IUserHelper, UserHelper>();
+builder.Services.AddSingleton<IContentHelper, ContentHelper>();
 builder.Services.AddSingleton<IValidator<UserEmailValidationModel>, UserEmailValidator>();
 builder.Services.AddSingleton<IValidator<UserModel>, UserModelValidator>();
 builder.Services.AddSingleton<IValidator<ContentIdValidationModel>, ContentIdValidator>();
@@ -75,7 +76,7 @@ builder.Services.AddScoped<ICommentService, CommentService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddTransient<ExceptionHandlingMiddleware>();
 builder.Services.AddTransient<IHttpContextAccessor, HttpContextAccessor>();
-builder.Services.AddTransient<IAuthorizationHelper<UserModel>, AuthorizationHelper<UserModel>>();
+builder.Services.AddTransient<IAuthorizationHelper, AuthorizationHelper>();
 
 builder.Services.AddCors(p => p.AddPolicy(ApplicationConstants.CorsPolicy, build =>
 {

--- a/backend/Services/ContentService.cs
+++ b/backend/Services/ContentService.cs
@@ -11,8 +11,6 @@ using Microsoft.Extensions.Options;
 using static Amazon.S3.HttpVerb;
 using Backend.Models.Validation;
 using System.Text.RegularExpressions;
-using System.Collections.Generic;
-using System;
 
 namespace Backend.Services
 {

--- a/backend/Services/Repository.cs
+++ b/backend/Services/Repository.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Options;
 using Backend.Models;
 using Util.Exceptions;
 using Backend.Models.Config;
-using System.Runtime.CompilerServices;
 
 namespace InstaConnect.Services
 {

--- a/backend/Services/UserService.cs
+++ b/backend/Services/UserService.cs
@@ -420,7 +420,7 @@ namespace Backend.Services
             List<UserModel> result = new List<UserModel>();
             foreach (var user in updatedUsers)
             {
-                var validationResult = _createUpdateUserValidator.Validate(user, options => options.IncludeRuleSets(ApplicationConstants.Update));
+                var validationResult = _createUpdateUserValidator.Validate(user, options => options.IncludeRuleSets(ApplicationConstants.Update) );
                 ThrowExceptions(validationResult);
 
                 user.Role = null;

--- a/backend/Util/AbstractHelper.cs
+++ b/backend/Util/AbstractHelper.cs
@@ -2,7 +2,7 @@
 
 namespace Backend.Util
 {
-    public abstract class Helper<T> where T : IInstaModel
+    public abstract class AbstractHelper<T> where T : IInstaModel
     {
         protected bool OnlyOneDifference(string? difference, HashSet<string>? list1, HashSet<string>? list2)
         {

--- a/backend/Util/CommentHelper.cs
+++ b/backend/Util/CommentHelper.cs
@@ -1,0 +1,23 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public class CommentHelper : AbstractHelper<CommentModel>, ICommentHelper
+    {
+        public bool CompareLikes(string loggedInUser, CommentModel a, CommentModel b)
+        {
+            if ((a.Id == null || b.Id == a.Id)
+                 && (a.Email == null || b.Email == a.Email)
+                 && (a.Body == null || b.Body == b.Body)
+                 && (a.Likes == null || GetDifference(b.Likes, a.Likes).Count == 0)
+                 && (a.Likes == null || OnlyOneDifference(loggedInUser, a.Likes, b.Likes)))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/backend/Util/CommentHelper.cs
+++ b/backend/Util/CommentHelper.cs
@@ -9,7 +9,6 @@ namespace Backend.Util
             if ((a.Id == null || b.Id == a.Id)
                  && (a.Email == null || b.Email == a.Email)
                  && (a.Body == null || b.Body == b.Body)
-                 && (a.Likes == null || GetDifference(b.Likes, a.Likes).Count == 0)
                  && (a.Likes == null || OnlyOneDifference(loggedInUser, a.Likes, b.Likes)))
             {
                 return true;

--- a/backend/Util/ContentHelper.cs
+++ b/backend/Util/ContentHelper.cs
@@ -2,7 +2,7 @@
 
 namespace Backend.Util
 {
-    public class ContentHelper : Helper<ContentModel>, IContentHelper
+    public class ContentHelper : AbstractHelper<ContentModel>, IContentHelper
     {
         public bool CompareLikes(string loggedInUser, ContentModel a, ContentModel b)
         {
@@ -10,7 +10,6 @@ namespace Backend.Util
                  && (a.Email == null || b.Email == a.Email)
                  && (a.Caption == null || b.Caption == a.Caption)
                  && (a.MediaType == null || b.MediaType == a.MediaType)
-                 && (a.Likes == null || GetDifference(b.Likes, a.Likes).Count == 0)
                  && (a.Likes == null || OnlyOneDifference(loggedInUser, a.Likes, b.Likes)))
             {
                 return true;

--- a/backend/Util/ContentHelper.cs
+++ b/backend/Util/ContentHelper.cs
@@ -1,0 +1,24 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public class ContentHelper : Helper<ContentModel>, IContentHelper
+    {
+        public bool CompareLikes(string loggedInUser, ContentModel a, ContentModel b)
+        {
+            if ((a.Id == null || b.Id == a.Id)
+                 && (a.Email == null || b.Email == a.Email)
+                 && (a.Caption == null || b.Caption == a.Caption)
+                 && (a.MediaType == null || b.MediaType == a.MediaType)
+                 && (a.Likes == null || GetDifference(b.Likes, a.Likes).Count == 0)
+                 && (a.Likes == null || OnlyOneDifference(loggedInUser, a.Likes, b.Likes)))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/backend/Util/Helper.cs
+++ b/backend/Util/Helper.cs
@@ -1,0 +1,23 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public abstract class Helper<T> where T : IInstaModel
+    {
+        protected bool OnlyOneDifference(string? difference, HashSet<string>? list1, HashSet<string>? list2)
+        {
+            if (difference == null || list1 == null || list2 == null)
+                return false;
+            var set = GetDifference(list1, list2);
+            if ((set.Count == 1 && set.Contains(difference))
+                || set.Count == 0)
+                return true;
+            return false;
+        }
+
+        protected HashSet<string> GetDifference(HashSet<string> h1, HashSet<string> h2)
+        {
+            return h1.Except(h2).Concat(h2.Except(h1)).ToHashSet();
+        }
+    }
+}

--- a/backend/Util/ICommentHelper.cs
+++ b/backend/Util/ICommentHelper.cs
@@ -1,0 +1,9 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public interface ICommentHelper
+    {
+        public bool CompareLikes(string loggedInUser, CommentModel a, CommentModel b);
+    }
+}

--- a/backend/Util/IContentHelper.cs
+++ b/backend/Util/IContentHelper.cs
@@ -1,0 +1,9 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public interface IContentHelper
+    {
+        public bool CompareLikes(string loggedInUser, ContentModel a, ContentModel b);
+    }
+}

--- a/backend/Util/IUserHelper.cs
+++ b/backend/Util/IUserHelper.cs
@@ -1,0 +1,9 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public interface IUserHelper
+    {
+        public bool CompareFollowers(string loggedInUser, UserModel a, UserModel b);
+    }
+}

--- a/backend/Util/UserHelper.cs
+++ b/backend/Util/UserHelper.cs
@@ -2,7 +2,7 @@
 
 namespace Backend.Util
 {
-    public class UserHelper : IUserHelper
+    public class UserHelper : Helper<UserModel>, IUserHelper
     {
         public bool CompareFollowers(string loggedInUser, UserModel a, UserModel b)
         {
@@ -12,7 +12,7 @@ namespace Backend.Util
                  && (a.FirstName == null || b.FirstName == a.FirstName)
                  && (a.LastName == null || b.LastName == a.LastName)
                  && (a.BirthDate == null || b.BirthDate == a.BirthDate)
-                 && (a.Following == null || GetDifference<string>(b.Following, a.Following).Count == 0)
+                 && (a.Following == null || GetDifference(b.Following, a.Following).Count == 0)
                  && (a.Role == null || b.Role == a.Role)
                  && (a.Followers == null || OnlyOneDifference(loggedInUser, a.Followers, b.Followers)))
             {
@@ -23,22 +23,5 @@ namespace Backend.Util
                 return false;
             }
         }
-
-        private bool OnlyOneDifference(string? difference, HashSet<string>? list1, HashSet<string>? list2)
-        {
-            if (difference == null || list1 == null || list2 == null)
-                return false;
-            var set = GetDifference<string>(list1, list2);
-            if ((set.Count == 1 && set.Contains(difference))
-                || set.Count == 0)
-                return true;
-            return false;
-        }
-
-        private HashSet<T> GetDifference<T>(HashSet<T> h1, HashSet<T> h2)
-        {
-            return h1.Except(h2).Concat(h2.Except(h1)).ToHashSet();
-        }
-
     }
 }

--- a/backend/Util/UserHelper.cs
+++ b/backend/Util/UserHelper.cs
@@ -1,0 +1,44 @@
+﻿using Backend.Models;
+
+namespace Backend.Util
+{
+    public class UserHelper : IUserHelper
+    {
+        public bool CompareFollowers(string loggedInUser, UserModel a, UserModel b)
+        {
+            if ((a.Id == null || b.Id == a.Id) 
+                 && (a.Email == null || b.Email == a.Email)
+                 && (a.Password == null || b.Password == a.Password)
+                 && (a.FirstName == null || b.FirstName == a.FirstName)
+                 && (a.LastName == null || b.LastName == a.LastName)
+                 && (a.BirthDate == null || b.BirthDate == a.BirthDate)
+                 && (a.Following == null || GetDifference<string>(b.Following, a.Following).Count == 0)
+                 && (a.Role == null || b.Role == a.Role)
+                 && (a.Followers == null || OnlyOneDifference(loggedInUser, a.Followers, b.Followers)))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private bool OnlyOneDifference(string? difference, HashSet<string>? list1, HashSet<string>? list2)
+        {
+            if (difference == null || list1 == null || list2 == null)
+                return false;
+            var set = GetDifference<string>(list1, list2);
+            if ((set.Count == 1 && set.Contains(difference))
+                || set.Count == 0)
+                return true;
+            return false;
+        }
+
+        private HashSet<T> GetDifference<T>(HashSet<T> h1, HashSet<T> h2)
+        {
+            return h1.Except(h2).Concat(h2.Except(h1)).ToHashSet();
+        }
+
+    }
+}

--- a/backend/Util/UserHelper.cs
+++ b/backend/Util/UserHelper.cs
@@ -2,7 +2,7 @@
 
 namespace Backend.Util
 {
-    public class UserHelper : Helper<UserModel>, IUserHelper
+    public class UserHelper : AbstractHelper<UserModel>, IUserHelper
     {
         public bool CompareFollowers(string loggedInUser, UserModel a, UserModel b)
         {

--- a/backend/Validators/UserValidators/UserModelValidator.cs
+++ b/backend/Validators/UserValidators/UserModelValidator.cs
@@ -11,11 +11,11 @@ namespace Backend.Validators.UserValidators
             RuleSet(ApplicationConstants.Create, () =>
             {
                 RuleFor(user => user.Email).Cascade(CascadeMode.Stop)
-                                        .NotEmpty().WithMessage(ApplicationConstants.EmailEmpty)
-                                        .EmailAddress().WithMessage(ApplicationConstants.EmailValid);
+                                           .NotEmpty().WithMessage(ApplicationConstants.EmailEmpty)
+                                           .EmailAddress().WithMessage(ApplicationConstants.EmailValid);
                 RuleFor(user => user.FirstName).Cascade(CascadeMode.Stop)
-                                                .NotEmpty().WithMessage(ApplicationConstants.FirstNameEmpty)
-                                                .Must(validator.IsValidName).WithMessage(ApplicationConstants.FirstNameValid);
+                                               .NotEmpty().WithMessage(ApplicationConstants.FirstNameEmpty)
+                                               .Must(validator.IsValidName).WithMessage(ApplicationConstants.FirstNameValid);
                 RuleFor(user => user.LastName).Cascade(CascadeMode.Stop)
                                               .NotEmpty().WithMessage(ApplicationConstants.LastNameEmpty)
                                               .Must(validator.IsValidName).WithMessage(ApplicationConstants.LastNameValid);
@@ -27,8 +27,8 @@ namespace Backend.Validators.UserValidators
             RuleSet(ApplicationConstants.Update, () =>
             {
                 RuleFor(user => user.FirstName).Cascade(CascadeMode.Stop)
-                                           .NotEmpty().WithMessage(ApplicationConstants.FirstNameEmpty)
-                                           .Must(validator.IsValidName).WithMessage(ApplicationConstants.FirstNameValid);
+                                               .NotEmpty().WithMessage(ApplicationConstants.FirstNameEmpty)
+                                               .Must(validator.IsValidName).WithMessage(ApplicationConstants.FirstNameValid);
                 RuleFor(user => user.LastName).Cascade(CascadeMode.Stop)
                                               .NotEmpty().WithMessage(ApplicationConstants.LastNameEmpty)
                                               .Must(validator.IsValidName).WithMessage(ApplicationConstants.LastNameValid);
@@ -43,8 +43,8 @@ namespace Backend.Validators.UserValidators
             RuleSet(ApplicationConstants.EmailService, () =>
             {
                 RuleFor(user => user.FirstName).Cascade(CascadeMode.Stop)
-                                           .NotEmpty().WithMessage(ApplicationConstants.FirstNameEmpty)
-                                           .Must(validator.IsValidName).WithMessage(ApplicationConstants.FirstNameValid);
+                                               .NotEmpty().WithMessage(ApplicationConstants.FirstNameEmpty)
+                                               .Must(validator.IsValidName).WithMessage(ApplicationConstants.FirstNameValid);
                 RuleFor(user => user.LastName).Cascade(CascadeMode.Stop)
                                               .NotEmpty().WithMessage(ApplicationConstants.LastNameEmpty)
                                               .Must(validator.IsValidName).WithMessage(ApplicationConstants.LastNameValid);

--- a/frontend/main/src/components/home-page/EditProfile.tsx
+++ b/frontend/main/src/components/home-page/EditProfile.tsx
@@ -104,6 +104,9 @@ export const EditProfile = ( props: EditProfileProps ) => {
                         toastContext.openToast(false, `Email To ${userResponse.email} Failed to Send To Update Your Password`)
                     }
                 }
+                else {
+                    toastContext.openToast(true, 'User Updates Made!')
+                }
             }
             else {
                 toastContext.openToast(false, 'No User Is Logged In!')


### PR DESCRIPTION
**Summary**
Different users are allowed to modify other user's `UserModel`, `ContentModel` or `CommentModel` based on what they are modifying. A user can follow another user buy making a PUT request with their email added under the `Following` field. Similarly a user can like another person's post by adding their user's email address to the HashSet `Likes` field on the `ContentModel` or `CommentModel` object. This PR improved the initial authorization framework I created to include these cases where we typically do not want other users modifying other users content but is allowed under certain circumstances. In large part this is possible with the following helper classes which I have added

- `AuthorizationHelper` [Backend.Authorization.Helpers]: This helper class is used across all the different classes used to define policies in authorization. It has one dependency `IHttpContextAccessor` which consolidates all logic with handling the request in this specific class.
- `AbstractHelper` [Backend.Utils]: This is an abstract class which is extends all the model specific helpers like `CommentHelper`, `ContentHelper`, etc. These helper classes are injected into the policy classes to assist with determining if objects that are not owned by the user requesting a change adheres to specific guidelines as described above.

**Testing**

- Test the endpoints and application for normal functionality; everything should work within the UI as it had before
- Verify that you can follow and stop following a user without an exception thrown
- Verify that if you try to follow a user with a different account than logged in it will return a `401` status code
- Verify that you can add and remove a like for contents and comments that is associated with the user's email address which is logged in
- Verify that if you try to like a comment or post with an account that is not logged in it will return a `401` status code.